### PR TITLE
[feature] 프로젝트 전역에서 발생하는 Exception 을 한 곳에서 처리한다.

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/.idea/KUDDY-back.iml
+++ b/.idea/KUDDY-back.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/KUDDY-back.iml" filepath="$PROJECT_DIR$/.idea/KUDDY-back.iml" />
-    </modules>
-  </component>
-</project>

--- a/kuddy-back/build.gradle
+++ b/kuddy-back/build.gradle
@@ -28,8 +28,12 @@ subprojects {
 
     dependencies {
         // 공통 의존성 (예: 모든 모듈에서 사용되는 라이브러리)
+
+        //spring boot
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         developmentOnly 'org.springframework.boot:spring-boot-devtools'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+
         //lombok
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'

--- a/kuddy-back/common/src/main/java/com/kuddy/common/exception/GlobalExceptionHandler.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,48 @@
+package com.kuddy.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.kuddy.common.exception.custom.ApplicationException;
+import com.kuddy.common.exception.dto.ErrorResponse;
+import com.kuddy.common.exception.type.ExceptionType;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(ApplicationException.class)
+	public ResponseEntity<ErrorResponse> applicationException(ApplicationException e) {
+		log.info(String.format("Application Exception : %s", e));
+		final ErrorResponse response = ErrorResponse.builder()
+			.status(e.getHttpStatus())
+			.code(e.getErrorCode())
+			.message(e.getMessage())
+			.build();
+		return ResponseEntity.status(response.getStatus()).body(response);
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> runtimeException(Exception e) {
+		StackTraceElement[] stackTrace = e.getStackTrace();
+		log.error(String.format("UnHandled Exception : %s\n" + "%s:%s:%s", e, stackTrace[0].getClassName(),
+			stackTrace[0].getMethodName(), stackTrace[0].getLineNumber()), e);
+		HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+		String message = ExceptionType.UNHANDLED_EXCEPTION.getMessage();
+		String errorCode = ExceptionType.UNHANDLED_EXCEPTION.getErrorCode();
+		return ResponseEntity.internalServerError().body(new ErrorResponse(status, errorCode, message));
+	}
+	@ExceptionHandler
+	public ResponseEntity<ErrorResponse> methodArgumentNotValidException(MethodArgumentNotValidException e) {
+		log.info(String.format("MethodArgumentNotValidException : %s", e));
+		HttpStatus status = HttpStatus.BAD_REQUEST;
+		String errorCode = ExceptionType.METHOD_ARGUMENT_NOT_VALID_EXCEPTION.getErrorCode();
+		String message = e.getAllErrors().get(0).getDefaultMessage();
+		return ResponseEntity.badRequest().body(new ErrorResponse(status, errorCode, message));
+	}
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/exception/custom/ApplicationException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/exception/custom/ApplicationException.java
@@ -1,0 +1,29 @@
+package com.kuddy.common.exception.custom;
+
+import org.springframework.http.HttpStatus;
+
+import com.kuddy.common.exception.type.ExceptionType;
+
+import lombok.Getter;
+
+@Getter
+public class ApplicationException extends RuntimeException { //에러 메시지 상세화를 위해
+
+	private final HttpStatus httpStatus;
+	private final String errorCode;
+	private final String message;
+
+	public ApplicationException(HttpStatus httpStatus) {
+		ExceptionType exceptionType = ExceptionType.from(this.getClass());
+		this.httpStatus = httpStatus;
+		this.errorCode = exceptionType.getErrorCode();
+		this.message = exceptionType.getMessage();
+	}
+
+	public ApplicationException(HttpStatus httpStatus, String optionalMessage) {
+		ExceptionType exceptionType = ExceptionType.from(this.getClass());
+		this.httpStatus = httpStatus;
+		this.errorCode = exceptionType.getErrorCode();
+		this.message = exceptionType.getMessage() + optionalMessage;
+	}
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/exception/custom/BadRequestException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/exception/custom/BadRequestException.java
@@ -1,0 +1,14 @@
+package com.kuddy.common.exception.custom;
+
+import org.springframework.http.HttpStatus;
+
+public class BadRequestException extends ApplicationException {
+
+	public BadRequestException() {
+		super(HttpStatus.BAD_REQUEST);
+	}
+
+	public BadRequestException(String optionalMessage) {
+		super(HttpStatus.BAD_REQUEST, optionalMessage);
+	}
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/exception/custom/ForbiddenException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/exception/custom/ForbiddenException.java
@@ -1,0 +1,14 @@
+package com.kuddy.common.exception.custom;
+
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenException extends ApplicationException {
+
+	public ForbiddenException() {
+		super(HttpStatus.FORBIDDEN);
+	}
+
+	public ForbiddenException(String optionalMessage) {
+		super(HttpStatus.FORBIDDEN, optionalMessage);
+	}
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/exception/custom/NotFoundException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/exception/custom/NotFoundException.java
@@ -1,0 +1,14 @@
+package com.kuddy.common.exception.custom;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends ApplicationException {
+
+	public NotFoundException() {
+		super(HttpStatus.NOT_FOUND);
+	}
+
+	public NotFoundException(String optionalMessage) {
+		super(HttpStatus.NOT_FOUND, optionalMessage);
+	}
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/exception/custom/UnAuthorizedException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/exception/custom/UnAuthorizedException.java
@@ -1,0 +1,10 @@
+package com.kuddy.common.exception.custom;
+
+import org.springframework.http.HttpStatus;
+
+public class UnAuthorizedException extends ApplicationException {
+
+	public UnAuthorizedException() {
+		super(HttpStatus.UNAUTHORIZED);
+	}
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/exception/dto/ErrorResponse.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/exception/dto/ErrorResponse.java
@@ -1,0 +1,30 @@
+package com.kuddy.common.exception.dto;
+
+import java.time.LocalDateTime;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ErrorResponse {
+	private HttpStatus status;
+	private String errorCode;
+	private String message;
+	private LocalDateTime date = LocalDateTime.now();
+
+	@Builder
+	public ErrorResponse(HttpStatus status, String code, String message) {
+		this.status = status;
+		this.errorCode = code;
+		this.message = message;
+	}
+
+
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/exception/type/ExceptionType.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/exception/type/ExceptionType.java
@@ -1,0 +1,57 @@
+package com.kuddy.common.exception.type;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import com.kuddy.common.exception.custom.ApplicationException;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ExceptionType {
+
+	// 서버 자체 관련 - C0***
+	UNHANDLED_EXCEPTION("C0000", "알 수 없는 서버 에러가 발생했습니다."),
+	METHOD_ARGUMENT_NOT_VALID_EXCEPTION("C0001", "요청 데이터가 잘못되었습니다.");
+
+
+	//권한 관련 - C1***
+
+	/* 예시
+	EMPTY_TOKEN_EXCEPTION("C1003", "토큰이 존재하지 않습니다.", EmptyTokenException.class),
+	INVALID_TOKEN_TYPE_EXCEPTION("C1004", "토큰 타입이 올바르지 않습니다.", InvalidTokenTypeException.class),
+	INVALID_TOKEN_EXCEPTION("C1005", "엑세스 토큰이 유효하지 않습니다.", InvalidAccessTokenException.class),
+	HTTP_REQUEST_NULL_EXCEPTION("C1006", "인증할 수 있는 사용자 데이터가 없습니다.", HttpRequestNullException.class),
+	NOT_AUTHOR_EXCEPTION("C1007", "작성자가 아니므로 권한이 없습니다.", NotAuthorException.class),
+	NOT_MEMBER_EXCEPTION("C1008", "회원이 아니므로 권한이 없습니다.", NotMemberException.class),
+	INVALID_REFRESH_TOKEN_EXCEPTION("C1009", "리프레시 토큰이 유효하지 않습니다.", InvalidRefreshTokenException.class),
+	UNAUTHORIZED_TOKEN_EXCEPTION("C1010", "유효한 액세스 토큰으로 리프레시 토큰을 발급할 수 없습니다.", UnAuthorizedTokenException.class),
+	INVALID_ACCESS_TOKEN_AT_RENEW_EXCEPTION("C1011", "유효하지 않는 액세스 토큰으로 권한이 없는 유저입니다. 재로그인을 해주세요",
+		InvalidAccessTokenAtRenewException.class);
+
+	 */
+
+	//회원 관련 - C2***
+	//프로필 관련 - C3***
+	//관광지 관련 - C4***
+	//게시글 관련 - C5***
+	//댓글 관련 - C6***
+
+	private final String errorCode;
+	private final String message;
+	private Class<? extends ApplicationException> type;
+
+	ExceptionType(String errorCode, String message) {
+		this.errorCode = errorCode;
+		this.message = message;
+	}
+
+	public static ExceptionType from(Class<?> classType) {
+		return Arrays.stream(values())
+			.filter(it -> Objects.nonNull(it.type) && it.type.equals(classType))
+			.findFirst()
+			.orElse(UNHANDLED_EXCEPTION);
+	}
+}


### PR DESCRIPTION
## 기능 명세
- [x] 커스텀 예외 처리
- [x] 예외 타입 정의 (각 상황마다 예외코드)
- [x] 전역 에러 핸들러로 Controller 내에서 발생하는 에러에 대해서 해당 핸들러에서 캐치하여 오류를 발생시키지 않고 응답 메시지로 클라이언트에게 전달

## 결과 
- 잘못된 메서드로 서버에게 요청할 때 응답값은 다음과 같습니다.
```json
{
    "status": "INTERNAL_SERVER_ERROR",
    "errorCode": "C0000",
    "message": "알 수 없는 서버 에러가 발생했습니다.",
    "date": "2023-08-17T23:57:51.493146"
}
```

## 함께 의논할 점
> - 없으면 생략 
close #1 