### PR TITLE
[feature] 소셜로그인을 구현한다.

### DIFF
--- a/kuddy-back/api-server/build.gradle
+++ b/kuddy-back/api-server/build.gradle
@@ -5,5 +5,4 @@ dependencies {
     //implementation project(path: ':common') //common 모듈을 반드시 Implementation
     implementation 'org.springframework.boot:spring-boot-starter-data-rest'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 }

--- a/kuddy-back/api-server/src/main/java/com/kuddy/apiserver/ApiServerApplication.java
+++ b/kuddy-back/api-server/src/main/java/com/kuddy/apiserver/ApiServerApplication.java
@@ -2,7 +2,9 @@ package com.kuddy.apiserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication(scanBasePackages = "com.kuddy")
 public class ApiServerApplication {
 

--- a/kuddy-back/api-server/src/main/java/com/kuddy/apiserver/ApiServerApplication.java
+++ b/kuddy-back/api-server/src/main/java/com/kuddy/apiserver/ApiServerApplication.java
@@ -2,9 +2,13 @@ package com.kuddy.apiserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @EnableJpaAuditing
+@EntityScan("com.kuddy.common")//@Entity , Spring Data Repository 관련 클래스들은 해당 패키지에 존재해도 인식을 할 수 없는 문제 해결
+@EnableJpaRepositories("com.kuddy.common")
 @SpringBootApplication(scanBasePackages = "com.kuddy")
 public class ApiServerApplication {
 

--- a/kuddy-back/api-server/src/main/java/com/kuddy/apiserver/member/controller/MemberController.java
+++ b/kuddy-back/api-server/src/main/java/com/kuddy/apiserver/member/controller/MemberController.java
@@ -1,0 +1,33 @@
+package com.kuddy.apiserver.member.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kuddy.apiserver.member.dto.MemberResDto;
+import com.kuddy.common.member.domain.Member;
+import com.kuddy.common.response.StatusEnum;
+import com.kuddy.common.response.StatusResponse;
+import com.kuddy.common.security.user.AuthUser;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+	@GetMapping("/me")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<StatusResponse> readMember(@AuthUser Member member) {
+		MemberResDto response = MemberResDto.of(member);
+		return ResponseEntity.ok(StatusResponse.builder()
+			.status(StatusEnum.OK.getStatusCode())
+			.message(StatusEnum.OK.getCode())
+			.data(response)
+			.build());
+	}
+}

--- a/kuddy-back/api-server/src/main/java/com/kuddy/apiserver/member/dto/MemberResDto.java
+++ b/kuddy-back/api-server/src/main/java/com/kuddy/apiserver/member/dto/MemberResDto.java
@@ -1,0 +1,27 @@
+package com.kuddy.apiserver.member.dto;
+
+import com.kuddy.common.member.domain.Member;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberResDto {
+	private String email;
+	private String nickname;
+	private String profileImageUrl;
+
+	public static MemberResDto of(Member member){
+		return MemberResDto.builder()
+			.email(member.getEmail())
+			.nickname(member.getNickname())
+			.profileImageUrl(member.getProfileImageUrl())
+			.build();
+	}
+
+
+}

--- a/kuddy-back/build.gradle
+++ b/kuddy-back/build.gradle
@@ -34,6 +34,9 @@ subprojects {
         developmentOnly 'org.springframework.boot:spring-boot-devtools'
         implementation 'org.springframework.boot:spring-boot-starter-web'
 
+        //jpa
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
         //lombok
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'

--- a/kuddy-back/build.gradle
+++ b/kuddy-back/build.gradle
@@ -34,9 +34,6 @@ subprojects {
         developmentOnly 'org.springframework.boot:spring-boot-devtools'
         implementation 'org.springframework.boot:spring-boot-starter-web'
 
-        //jpa
-        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-
         //lombok
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'

--- a/kuddy-back/chat-server/build.gradle
+++ b/kuddy-back/chat-server/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     //DB
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
+
     //websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 

--- a/kuddy-back/chat-server/src/main/java/com/kuddy/chatserver/ChatServerApplication.java
+++ b/kuddy-back/chat-server/src/main/java/com/kuddy/chatserver/ChatServerApplication.java
@@ -2,7 +2,9 @@ package com.kuddy.chatserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication(scanBasePackages = "com.kuddy")
 public class ChatServerApplication {
 

--- a/kuddy-back/common/build.gradle
+++ b/kuddy-back/common/build.gradle
@@ -10,10 +10,19 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
     implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
     implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
+
+    //Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    // oauth2-client 라이브러리
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa' //implementation 은 직접 의존하고 있는 자신만 그 구현을 알고 있으며, 그 자식 모듈(?) 은 해당 의존성에 대한 구현을 참조할 수 없기 때문에, 이것을 api로 변경을 해서 사용
+
 
 }
 

--- a/kuddy-back/common/src/main/java/com/kuddy/common/config/RedisConfiguration.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/config/RedisConfiguration.java
@@ -1,0 +1,45 @@
+package com.kuddy.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfiguration {
+
+	@Value("${spring.redis.host}")
+	private String host;
+
+	@Value("${spring.redis.port}")
+	private int port;
+
+	//@Value("${spring.redis.password}")
+	//private String password;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+		redisStandaloneConfiguration.setHostName(host);
+		redisStandaloneConfiguration.setPort(port);
+		//redisStandaloneConfiguration.setPassword(password);
+
+		return new LettuceConnectionFactory(redisStandaloneConfiguration);
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate() {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		// 일반적인 문자열 key value의 경우 시리얼라이저 설정
+		// redis-cli로 데이터를 확인할 때 알아볼 수 있는 형태로 표시해준다.
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+		return redisTemplate;
+	}
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/config/SecurityConfiguration.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/config/SecurityConfiguration.java
@@ -70,6 +70,7 @@ public class SecurityConfiguration {
 			.userService(customOAuth2UserService)
 			.and()
 			.successHandler(oAuth2AuthenticationSuccessHandler)
+			.failureHandler(oAuth2AuthenticationFailureHandler)
 
 			.and() // 시큐리티는 기본적으로 세션을 사용하지만, 우리는 세션을 사용하지 않기 때문에 Stateless로 설정
 			.sessionManagement()
@@ -94,7 +95,6 @@ public class SecurityConfiguration {
 		configuration.addAllowedHeader("*");
 		configuration.addAllowedMethod("*");
 		configuration.addAllowedOrigin("http://localhost:3000");
-		configuration.addAllowedOrigin("http://localhost:5500");
 		configuration.setAllowCredentials(true);
 		configuration.setAllowedOriginPatterns(Collections.singletonList("*"));
 

--- a/kuddy-back/common/src/main/java/com/kuddy/common/config/SecurityConfiguration.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/config/SecurityConfiguration.java
@@ -1,0 +1,107 @@
+package com.kuddy.common.config;
+
+
+import java.util.Collections;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import com.kuddy.common.jwt.JwtAccessDeniedHandler;
+import com.kuddy.common.jwt.JwtEntryPoint;
+import com.kuddy.common.jwt.JwtFilter;
+import com.kuddy.common.security.repository.CookieAuthorizationRequestRepository;
+import com.kuddy.common.security.service.CustomOAuth2UserService;
+import com.kuddy.common.security.service.OAuth2AuthenticationFailureHandler;
+import com.kuddy.common.security.service.OAuth2AuthenticationSuccessHandler;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableMethodSecurity(prePostEnabled = true) // preAuthorize 활성화
+@EnableWebSecurity  // Spring Security 설정 활성화
+@RequiredArgsConstructor
+public class SecurityConfiguration {
+
+	private final JwtEntryPoint jwtEntryPoint;
+	private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+	private final JwtFilter jwtFilter;
+	private final CustomOAuth2UserService customOAuth2UserService;
+	private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+	private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+
+	private final CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
+
+	// Spring Security에서 제공하는 비밀번호 암호화 클래스.
+	// Service에서 사용할 수 있도록 Bean으로 등록한다.
+	@Bean
+	public BCryptPasswordEncoder bCryptPasswordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf().disable() // Non-Browser Clients만을 위한 API 서버이므로, csrf 보호기능 해제
+			.headers().frameOptions().sameOrigin() // h2-console 화면을 보기 위한 처리.
+
+			.and()
+			.authorizeRequests() // URL 별로 리소스에 대한 접근 권한 관리
+			.anyRequest().permitAll()// 우선 다 허용
+			.and()
+			.cors().configurationSource(corsConfigurationSource()) // CorsConfigurationSource 를 cors 정책의 설정파일 등록
+
+			.and()
+			.oauth2Login() // oauth2 로그인 시작점
+			.authorizationEndpoint()
+			//  인증 요청을 쿠키에 임시 보관하는 리포지토리에 대한 설정으로, 인증 후 프론트에 redirect할 url이 저장되어 있다.
+			.authorizationRequestRepository(cookieAuthorizationRequestRepository)
+			.and()
+			.userInfoEndpoint() // 로그인 성공하면 사용자 정보 가져올 때 설정을 담당
+			.userService(customOAuth2UserService)
+			.and()
+			.successHandler(oAuth2AuthenticationSuccessHandler)
+
+			.and() // 시큐리티는 기본적으로 세션을 사용하지만, 우리는 세션을 사용하지 않기 때문에 Stateless로 설정
+			.sessionManagement()
+			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+			.and()
+			// JwtFilter를 인증을 처리하는 UsernamePasswordAuthenticationFilter 전에 추가한다.
+			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+
+			.exceptionHandling() // 예외 처리 기능 작동
+			.authenticationEntryPoint(jwtEntryPoint) // 인증 실패시 처리
+			.accessDeniedHandler(jwtAccessDeniedHandler); // 인가 실패시 처리
+
+		return http.build();
+	}
+
+	// CORS 허용 적용
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+
+		configuration.addAllowedHeader("*");
+		configuration.addAllowedMethod("*");
+		configuration.addAllowedOrigin("http://localhost:3000");
+		configuration.addAllowedOrigin("http://localhost:5500");
+		configuration.setAllowCredentials(true);
+		configuration.setAllowedOriginPatterns(Collections.singletonList("*"));
+
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
+	}
+}
+

--- a/kuddy-back/common/src/main/java/com/kuddy/common/domain/BaseTimeEntity.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/domain/BaseTimeEntity.java
@@ -1,4 +1,4 @@
-package com.kuddy.common.entity;
+package com.kuddy.common.domain;
 
 import java.time.LocalDateTime;
 

--- a/kuddy-back/common/src/main/java/com/kuddy/common/entity/BaseTimeEntity.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/entity/BaseTimeEntity.java
@@ -1,0 +1,27 @@
+package com.kuddy.common.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+	@CreatedDate
+	@Column(updatable = false)
+	private LocalDateTime createdDate;
+
+	@LastModifiedDate
+	@Column(insertable=false)
+	private LocalDateTime modifiedDate;
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/exception/custom/UnAuthorizedException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/exception/custom/UnAuthorizedException.java
@@ -7,4 +7,5 @@ public class UnAuthorizedException extends ApplicationException {
 	public UnAuthorizedException() {
 		super(HttpStatus.UNAUTHORIZED);
 	}
+
 }

--- a/kuddy-back/common/src/main/java/com/kuddy/common/exception/dto/ErrorResponse.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/exception/dto/ErrorResponse.java
@@ -1,23 +1,19 @@
 package com.kuddy.common.exception.dto;
 
-import java.time.LocalDateTime;
 
 import org.springframework.http.HttpStatus;
 
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class ErrorResponse {
 	private HttpStatus status;
 	private String errorCode;
 	private String message;
-	private LocalDateTime date = LocalDateTime.now();
 
 	@Builder
 	public ErrorResponse(HttpStatus status, String code, String message) {

--- a/kuddy-back/common/src/main/java/com/kuddy/common/exception/type/ExceptionType.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/exception/type/ExceptionType.java
@@ -4,6 +4,13 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import com.kuddy.common.exception.custom.ApplicationException;
+import com.kuddy.common.security.exception.EmptyTokenException;
+import com.kuddy.common.security.exception.InvalidAccessTokenAtRenewException;
+import com.kuddy.common.security.exception.ExpiredTokenException;
+import com.kuddy.common.security.exception.InvalidRefreshTokenException;
+import com.kuddy.common.security.exception.InvalidTokenException;
+import com.kuddy.common.security.exception.InvalidTokenTypeException;
+import com.kuddy.common.security.exception.UnAuthorizedTokenException;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,24 +21,26 @@ public enum ExceptionType {
 
 	// 서버 자체 관련 - C0***
 	UNHANDLED_EXCEPTION("C0000", "알 수 없는 서버 에러가 발생했습니다."),
-	METHOD_ARGUMENT_NOT_VALID_EXCEPTION("C0001", "요청 데이터가 잘못되었습니다.");
+	METHOD_ARGUMENT_NOT_VALID_EXCEPTION("C0001", "요청 데이터가 잘못되었습니다."),
 
 
 	//권한 관련 - C1***
 
-	/* 예시
-	EMPTY_TOKEN_EXCEPTION("C1003", "토큰이 존재하지 않습니다.", EmptyTokenException.class),
-	INVALID_TOKEN_TYPE_EXCEPTION("C1004", "토큰 타입이 올바르지 않습니다.", InvalidTokenTypeException.class),
-	INVALID_TOKEN_EXCEPTION("C1005", "엑세스 토큰이 유효하지 않습니다.", InvalidAccessTokenException.class),
-	HTTP_REQUEST_NULL_EXCEPTION("C1006", "인증할 수 있는 사용자 데이터가 없습니다.", HttpRequestNullException.class),
+	EMPTY_TOKEN_EXCEPTION("C1003", "토큰이 존재하지 않습니다.", EmptyTokenException .class),
+	INVALID_TOKEN_TYPE_EXCEPTION("C1004", "토큰 타입이 올바르지 않습니다.", InvalidTokenTypeException .class),
+	EXPIRED_TOKEN_EXCEPTION("C1005", "토큰이 유효하지 않습니다.", ExpiredTokenException.class),
+	/*HTTP_REQUEST_NULL_EXCEPTION("C1006", "인증할 수 있는 사용자 데이터가 없습니다.", HttpRequestNullException.class),
 	NOT_AUTHOR_EXCEPTION("C1007", "작성자가 아니므로 권한이 없습니다.", NotAuthorException.class),
 	NOT_MEMBER_EXCEPTION("C1008", "회원이 아니므로 권한이 없습니다.", NotMemberException.class),
+
+	 */
 	INVALID_REFRESH_TOKEN_EXCEPTION("C1009", "리프레시 토큰이 유효하지 않습니다.", InvalidRefreshTokenException.class),
 	UNAUTHORIZED_TOKEN_EXCEPTION("C1010", "유효한 액세스 토큰으로 리프레시 토큰을 발급할 수 없습니다.", UnAuthorizedTokenException.class),
 	INVALID_ACCESS_TOKEN_AT_RENEW_EXCEPTION("C1011", "유효하지 않는 액세스 토큰으로 권한이 없는 유저입니다. 재로그인을 해주세요",
-		InvalidAccessTokenAtRenewException.class);
+		InvalidAccessTokenAtRenewException.class),
+	INVALID_TOKEN_EXCEPTION("C1012", "토큰이 유효하지 않습니다.", InvalidTokenException.class);
 
-	 */
+
 
 	//회원 관련 - C2***
 	//프로필 관련 - C3***

--- a/kuddy-back/common/src/main/java/com/kuddy/common/jwt/JwtAccessDeniedHandler.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,33 @@
+package com.kuddy.common.jwt;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import net.minidev.json.JSONObject;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws
+		IOException {
+
+		log.error("Forbidden Error : {}", accessDeniedException.getMessage());
+		response.setContentType("application/json");
+		response.setCharacterEncoding("utf-8");
+		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+		response.getWriter().write(new JSONObject()
+			.put("message", accessDeniedException.getMessage()).toString());
+	}
+}
+

--- a/kuddy-back/common/src/main/java/com/kuddy/common/jwt/JwtEntryPoint.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/jwt/JwtEntryPoint.java
@@ -1,0 +1,49 @@
+package com.kuddy.common.jwt;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import net.minidev.json.JSONObject;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kuddy.common.exception.dto.ErrorResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtEntryPoint implements AuthenticationEntryPoint { //인증에 실패할 경우 진행될 EntryPoint를 생성
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+
+		log.error("Unauthorized Error : {}", authException.getMessage());
+		// ErrorResponse 객체 생성
+		ErrorResponse errorResponse = ErrorResponse.builder()
+			.status(HttpStatus.UNAUTHORIZED)
+			.code("AUTH_ERROR")
+			.message(authException.getMessage())
+			.build();
+
+		// JSON으로 변환
+		ObjectMapper objectMapper = new ObjectMapper();
+		String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+
+		// 응답 설정
+		response.setContentType("application/json");
+		response.setCharacterEncoding("utf-8");
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.getWriter().write(jsonResponse);
+	}
+
+
+}
+

--- a/kuddy-back/common/src/main/java/com/kuddy/common/jwt/JwtFilter.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/jwt/JwtFilter.java
@@ -1,0 +1,63 @@
+package com.kuddy.common.jwt;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.kuddy.common.redis.RedisService;
+import com.kuddy.common.security.exception.InvalidRefreshTokenException;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+	private final JwtProvider jwtProvider;
+
+	private final RedisService redisService;
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+		throws ServletException, IOException {
+
+		// HTTP Request Header에서 Token 값 가져오기
+		String jwt = resolveToken(request);
+
+		// 유효성 검사 후, 정상적인 토큰인 경우 Security Context에 저장한다.
+		if (StringUtils.hasText(jwt) && jwtProvider.validateToken(jwt)) {
+
+			// BlackList에 존재하는 토큰으로 요청이 온 경우.
+			Optional<String> isBlackList = redisService.getBlackList(jwt);
+			isBlackList.ifPresent(t -> {
+				throw new InvalidRefreshTokenException();
+			});
+
+			Authentication authentication = jwtProvider.getAuthentication(jwt);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+		filterChain.doFilter(request, response);
+	}
+
+	// HTTP Request Header에서 Token 값 가져오기
+	public String resolveToken(HttpServletRequest request) {
+		// Header의 Authorization에 JWT이 담겨 올 것이다.
+		String authorization = request.getHeader("Authorization");
+		// Authorization에 들어있는 문자열이 공백이 아니고 Bearer로 시작하는지 검증한다.
+		if (StringUtils.hasText(authorization) && authorization.startsWith("Bearer ")) {
+			// Token 값만 추출한다.
+			return authorization.substring(7);
+		}
+		return null;
+	}
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/jwt/JwtProvider.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/jwt/JwtProvider.java
@@ -1,0 +1,155 @@
+package com.kuddy.common.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import com.kuddy.common.exception.custom.UnAuthorizedException;
+import com.kuddy.common.redis.RedisService;
+import com.kuddy.common.security.exception.ExpiredTokenException;
+import com.kuddy.common.security.exception.InvalidTokenException;
+import com.kuddy.common.security.exception.InvalidTokenTypeException;
+import com.kuddy.common.security.service.UserDetailsServcieImpl;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+	private final RedisService redisService;
+
+	private final UserDetailsServcieImpl userDetailsService;
+
+	@Value("${spring.jwt.secret-key}")
+	private String secretKey;
+
+	private static final Long accessTokenValidationMs = 30 * 60 * 1000L;
+	private static final Long refreshTokenValidationMs = 15 * 24 * 60 * 60 * 1000L;
+
+	public Long getRefreshTokenValidationMs() { // Redis에 저장 시 사용
+		return refreshTokenValidationMs;
+	}
+
+	// AccessToken 생성
+	public String generateAccessToken(String email) {
+
+		// Registered claim. 토큰에 대한 정보들이 담겨있는 클레임. 이미 이름이 등록되어있다.
+		Claims claims = Jwts.claims()
+			// 토큰 제목(sub). 고유 식별자를 넣는다.
+			.setSubject(email)
+			// 발급 시간(iat)
+			.setIssuedAt(new Date())
+			// 만료 시간(exp)
+			.setExpiration(new Date(System.currentTimeMillis() + accessTokenValidationMs));
+
+
+		return Jwts.builder()
+			// 헤더의 타입(typ)을 jwt로 설정
+			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+			// 생성된 Claims 등록
+			.setClaims(claims)
+			// 서명에 사용할 키와 해싱 알고리즘(alt) 설정
+			.signWith(getSignKey(secretKey), SignatureAlgorithm.HS256)
+			// JWT 생성
+			.compact();
+	}
+
+	// RefreshToken 생성
+	public String generateRefreshToken(String email) {
+
+		Claims claims = Jwts.claims()
+			.setSubject(email)
+			.setIssuedAt(new Date())
+			.setExpiration(new Date(System.currentTimeMillis() + refreshTokenValidationMs));
+		return Jwts.builder()
+			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+			.setClaims(claims)
+			.signWith(getSignKey(secretKey), SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	// String인 secretKey를 byte[]로 변환 후 반환한다.
+	private Key getSignKey(String secretKey) {
+		return Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+	}
+
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parserBuilder()
+				.setSigningKey(getSignKey(secretKey))
+				.build()
+				.parseClaimsJws(token);
+			return true;
+		} catch (ExpiredJwtException e) {
+			log.error("만료된 토큰입니다. {}", e.toString());
+			throw new ExpiredTokenException();
+		} catch (UnsupportedJwtException e) {
+			log.error("잘못된 형식의 토큰입니다. {}", e.toString());
+			throw new InvalidTokenTypeException();
+		} catch (MalformedJwtException e) {
+			log.error("잘못된 구조의 토큰입니다. {}", e.toString());
+			throw new InvalidTokenTypeException();
+		}
+		catch (IllegalArgumentException e) {
+			log.error("잘못 생성된 토큰입니다. {}", e.toString());
+			throw new InvalidTokenException();
+		}
+	}
+
+	// JWT payload를 복호화해서 반환
+	private Claims getClaims(String token) {
+		try {
+			return Jwts.parserBuilder() // JwtParserBuilder 인스턴스 생성
+				.setSigningKey(getSignKey(secretKey)) // JWT Signature 검증을 위한 SecretKey 설정
+				.build() // Thread-Safe한 JwtParser를 반환하기 위해 build 호출
+				.parseClaimsJws(token) // Claim(Payload) 파싱
+				.getBody();
+		} catch (ExpiredJwtException e) {
+			// 만료된 토큰이어도 refresh token 검증 후 재발급할 수 있또록 claims 반환
+			return e.getClaims();
+		} catch (Exception e) {
+			// 다른 예외인 경우 throw
+			log.error("유효하지 않은 토큰입니다. {}", e.toString());
+			throw new InvalidTokenException();
+		}
+	}
+
+	public Authentication getAuthentication(String token) {
+
+		Claims claims = getClaims(token);
+		String email = claims.getSubject();
+
+		if (email == null) {
+			log.error("권한 정보가 없는 토큰입니다. {}", token);
+			throw new UnAuthorizedException();
+		}
+
+		UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+		return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+	}
+
+	public Long getRemainingTime(String token) {
+		Date expiration = getClaims(token).getExpiration();
+		Date now = new Date();
+		return expiration.getTime() - now.getTime();
+	}
+
+
+
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/member/domain/Member.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/member/domain/Member.java
@@ -1,0 +1,68 @@
+package com.kuddy.common.member.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import com.kuddy.common.domain.BaseTimeEntity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Member extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "member_id", updatable = false)
+	private Long id;
+
+	private String username;
+
+	@Column(name = "email", nullable = false)
+	private String email;
+
+	@Column(name = "profile_image_url")
+	private String profileImageUrl;
+
+	@Column(length = 50)
+	private String nickname;
+
+	@Column(length = 20)
+	@Enumerated(EnumType.STRING)
+	private ProviderType providerType;
+
+	@Column(length = 20)
+	@Enumerated(EnumType.STRING)
+	private RoleType roleType;
+
+
+	@Builder
+	public Member(String username, String email, String profileImageUrl, String nickname,
+		ProviderType providerType, RoleType roleType) {
+		this.username = username;
+		this.email = email;
+		this.profileImageUrl = profileImageUrl;
+		this.nickname = nickname;
+		this.providerType = providerType;
+		this.roleType = roleType;
+	}
+
+	public void updateMember(String email){
+		this.email = email;
+	}
+
+	public void updateNickname(String nickname){
+		this.nickname = nickname;
+	}
+
+
+	public void updateRole(RoleType roleType){this.roleType = roleType;}
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/member/domain/MemberAdapter.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/member/domain/MemberAdapter.java
@@ -1,0 +1,23 @@
+package com.kuddy.common.member.domain;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import lombok.Getter;
+
+@Getter
+public class MemberAdapter extends User { //본 Member에 바로 User을 상속 받으면 도메인 객체는 특정 기능에 종속되므로 Best prac 이 아님
+	private Member member;
+
+	public MemberAdapter(Member member) {
+		super(member.getEmail(), member.getUsername(), createAuthorities(member.getRoleType()));
+		this.member = member;
+	}
+	private static List<GrantedAuthority> createAuthorities(RoleType roleType) {
+		return Collections.singletonList(new SimpleGrantedAuthority(roleType.getCode()));
+	}
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/member/domain/MemberAdapter.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/member/domain/MemberAdapter.java
@@ -10,7 +10,7 @@ import org.springframework.security.core.userdetails.User;
 import lombok.Getter;
 
 @Getter
-public class MemberAdapter extends User { //본 Member에 바로 User을 상속 받으면 도메인 객체는 특정 기능에 종속되므로 Best prac 이 아님
+public class MemberAdapter extends User {
 	private Member member;
 
 	public MemberAdapter(Member member) {

--- a/kuddy-back/common/src/main/java/com/kuddy/common/member/domain/ProviderType.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/member/domain/ProviderType.java
@@ -1,0 +1,9 @@
+package com.kuddy.common.member.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum ProviderType {
+	GOOGLE,
+	KAKAO;
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/member/domain/RoleType.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/member/domain/RoleType.java
@@ -1,0 +1,27 @@
+package com.kuddy.common.member.domain;
+
+import java.util.Arrays;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum RoleType {
+	MEMBER("ROLE_USER", "member"),
+	KUDDY("ROLE_KUDDY", "k-buddy"),
+	TRAVELER("ROLE_TRAVELER", "traveler"),
+
+	ADMIN("ROLE_ADMIN", "admin"),
+	GUEST("GUEST", "guest");
+
+	private final String code;
+	private final String displayName;
+
+	public static RoleType of(String code) {
+		return Arrays.stream(RoleType.values())
+			.filter(r -> r.getCode().equals(code))
+			.findAny()
+			.orElse(GUEST);
+	}
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/member/exception/MemberNotFoundException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/member/exception/MemberNotFoundException.java
@@ -2,10 +2,10 @@ package com.kuddy.common.member.exception;
 
 import com.kuddy.common.exception.custom.NotFoundException;
 
-public class MemberNotFoundException extends NotFoundException {
+import lombok.NoArgsConstructor;
 
-	public MemberNotFoundException() {
-	}
+@NoArgsConstructor
+public class MemberNotFoundException extends NotFoundException {
 
 	public MemberNotFoundException(String memberEmail) {
 		super("member email : " + memberEmail);

--- a/kuddy-back/common/src/main/java/com/kuddy/common/member/exception/MemberNotFoundException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/member/exception/MemberNotFoundException.java
@@ -1,0 +1,13 @@
+package com.kuddy.common.member.exception;
+
+import com.kuddy.common.exception.custom.NotFoundException;
+
+public class MemberNotFoundException extends NotFoundException {
+
+	public MemberNotFoundException() {
+	}
+
+	public MemberNotFoundException(String memberEmail) {
+		super("member email : " + memberEmail);
+	}
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/member/repository/MemberRepository.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/member/repository/MemberRepository.java
@@ -1,0 +1,15 @@
+package com.kuddy.common.member.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kuddy.common.member.domain.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+	Optional<Member> findByEmail(String email);
+
+	boolean existsByEmail(String email);
+
+	Optional<Member> findByUsername(String username);
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/redis/RedisService.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/redis/RedisService.java
@@ -1,0 +1,38 @@
+package com.kuddy.common.redis;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	public void setData(String key, String value, Long expiredTime){
+		redisTemplate.opsForValue().set(key, value, expiredTime, TimeUnit.MILLISECONDS);
+	}
+
+	public String getData(String key){
+		return (String) redisTemplate.opsForValue().get(key);
+	}
+
+	public void deleteData(String key){
+		redisTemplate.delete(key);
+	}
+
+	public Optional<String> getRefreshToken(String accountId){
+		return Optional.ofNullable(getData("RefreshToken:" + accountId));
+	}
+	public Optional<String> getBlackList(String accessToken){
+		return Optional.ofNullable(getData("BlackList:" + accessToken));
+	}
+
+
+
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/response/StatusEnum.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/response/StatusEnum.java
@@ -1,0 +1,21 @@
+package com.kuddy.common.response;
+
+import lombok.Getter;
+
+@Getter
+public enum StatusEnum {
+
+	OK(200, "SUCCESS"),
+	CREATED(201, "CREATED"),
+	BAD_REQUEST(400, "BAD_REQUEST"),
+	NOT_FOUND(404, "NOT_FOUND"),
+	INTERNAL_SERER_ERROR(500, "INTERNAL_SERVER_ERROR");
+
+	Integer statusCode;
+	String code;
+
+	StatusEnum(Integer statusCode, String code) {
+		this.statusCode = statusCode;
+		this.code = code;
+	}
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/response/StatusResponse.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/response/StatusResponse.java
@@ -1,0 +1,19 @@
+package com.kuddy.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StatusResponse {
+
+	private Integer status;
+	private String message;
+	private Object data;
+
+
+
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/AuthExceptionHandler.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/AuthExceptionHandler.java
@@ -1,39 +1,39 @@
-package com.kuddy.common.jwt;
+package com.kuddy.common.security.exception;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
-import net.minidev.json.JSONObject;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kuddy.common.exception.custom.UnAuthorizedException;
 import com.kuddy.common.exception.dto.ErrorResponse;
-import com.kuddy.common.security.exception.InvalidTokenTypeException;
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-public class JwtEntryPoint implements AuthenticationEntryPoint { //인증에 실패할 경우 진행될 EntryPoint를 생성
-
-	@Override
-	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
-		// 이미 응답이 커밋된 경우, 더 이상 응답을 보내지 않는다.
-		if (response.isCommitted()) {
-			return;
+public class AuthExceptionHandler {
+	public void handleException(HttpServletResponse response,
+		UnAuthorizedException ex) throws IOException {
+		if (ex instanceof InvalidTokenTypeException) {
+			commence(response, ex);
+		} else if (ex instanceof InvalidTokenException) {
+			commence(response, ex);
 		}
+		else if (ex instanceof ExpiredTokenException) {
+			commence(response, ex);
+		}
+	}
+	public void commence(HttpServletResponse response, UnAuthorizedException authException) throws
+		IOException {
+
 		log.error("Unauthorized Error : {}", authException.getMessage());
 		// ErrorResponse 객체 생성
 		ErrorResponse errorResponse = ErrorResponse.builder()
 			.status(HttpStatus.UNAUTHORIZED)
-			.code("AUTH_ERROR")
+			.code(authException.getErrorCode())
 			.message(authException.getMessage())
 			.build();
 
@@ -47,7 +47,4 @@ public class JwtEntryPoint implements AuthenticationEntryPoint { //인증에 실
 		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 		response.getWriter().write(jsonResponse);
 	}
-
-
 }
-

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/EmptyTokenException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/EmptyTokenException.java
@@ -1,0 +1,9 @@
+package com.kuddy.common.security.exception;
+
+import com.kuddy.common.exception.custom.UnAuthorizedException;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class EmptyTokenException extends UnAuthorizedException {
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/ExpiredTokenException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/ExpiredTokenException.java
@@ -1,0 +1,9 @@
+package com.kuddy.common.security.exception;
+
+import com.kuddy.common.exception.custom.UnAuthorizedException;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class ExpiredTokenException extends UnAuthorizedException {
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/InvalidAccessTokenAtRenewException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/InvalidAccessTokenAtRenewException.java
@@ -1,0 +1,4 @@
+package com.kuddy.common.security.exception;
+
+public class InvalidAccessTokenAtRenewException extends UnAuthorizedTokenException{
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/InvalidAccessTokenAtRenewException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/InvalidAccessTokenAtRenewException.java
@@ -1,4 +1,7 @@
 package com.kuddy.common.security.exception;
 
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
 public class InvalidAccessTokenAtRenewException extends UnAuthorizedTokenException{
 }

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/InvalidRefreshTokenException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,6 @@
+package com.kuddy.common.security.exception;
+
+import com.kuddy.common.exception.custom.UnAuthorizedException;
+
+public class InvalidRefreshTokenException extends UnAuthorizedException {
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/InvalidTokenException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/InvalidTokenException.java
@@ -1,4 +1,7 @@
 package com.kuddy.common.security.exception;
 
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
 public class InvalidTokenException extends UnAuthorizedTokenException{
 }

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/InvalidTokenException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/InvalidTokenException.java
@@ -1,0 +1,4 @@
+package com.kuddy.common.security.exception;
+
+public class InvalidTokenException extends UnAuthorizedTokenException{
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/InvalidTokenTypeException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/InvalidTokenTypeException.java
@@ -1,0 +1,6 @@
+package com.kuddy.common.security.exception;
+
+import com.kuddy.common.exception.custom.UnAuthorizedException;
+
+public class InvalidTokenTypeException extends UnAuthorizedException {
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/InvalidTokenTypeException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/InvalidTokenTypeException.java
@@ -2,5 +2,8 @@ package com.kuddy.common.security.exception;
 
 import com.kuddy.common.exception.custom.UnAuthorizedException;
 
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
 public class InvalidTokenTypeException extends UnAuthorizedException {
 }

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/UnAuthorizedTokenException.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/exception/UnAuthorizedTokenException.java
@@ -5,5 +5,5 @@ import com.kuddy.common.exception.custom.UnAuthorizedException;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class InvalidRefreshTokenException extends UnAuthorizedException {
+public class UnAuthorizedTokenException extends UnAuthorizedException {
 }

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/repository/CookieAuthorizationRequestRepository.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/repository/CookieAuthorizationRequestRepository.java
@@ -1,0 +1,55 @@
+package com.kuddy.common.security.repository;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import com.kuddy.common.util.CookieUtils;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+
+@Component
+public class CookieAuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+	public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_KEY = "oauth2AuthRequest";
+	public static final String REDIRECT_URL_PARAM_COOKIE_KEY = "redirect_uri";
+	private static final int cookieExpireSeconds = 180;
+
+	// 쿠키에 저장된 인증요청 정보 가져옴
+	@Override
+	public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+		OAuth2AuthorizationRequest oAuth2AuthorizationRequest =  CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_KEY)
+			.map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+			.orElse(null);
+		return oAuth2AuthorizationRequest;
+	}
+
+	// 주어진 OAuth2 인증 요청을 쿠키에 저장합니다. 만약 인증 요청이 null이라면, 현재 쿠키에 저장된 인증 요청을 삭제합니다.
+	@Override
+	public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+		if (authorizationRequest == null) {
+			removeAuthorizationRequest(request, response);
+			return;
+		}
+		CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_KEY, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
+		String redirectUriAfterLogin = request.getParameter(REDIRECT_URL_PARAM_COOKIE_KEY);
+		if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+			CookieUtils.addCookie(response, REDIRECT_URL_PARAM_COOKIE_KEY, redirectUriAfterLogin, cookieExpireSeconds);
+		}
+	}
+
+	// 현재 HTTP request에서 OAuth2 인증 요청을 삭제하고, 삭제된 요청을 반환합니다.
+	@Override
+	public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+		return this.loadAuthorizationRequest(request);
+	}
+
+	//현재 HTTP 요청과 응답에서 OAuth2 인증 요청과 관련된 쿠키를 모두 삭제합니다.
+	public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+		CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_KEY);
+		CookieUtils.deleteCookie(request, response, REDIRECT_URL_PARAM_COOKIE_KEY);
+	}
+
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/service/CustomOAuth2UserService.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/service/CustomOAuth2UserService.java
@@ -1,0 +1,85 @@
+package com.kuddy.common.security.service;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kuddy.common.member.domain.Member;
+import com.kuddy.common.member.domain.RoleType;
+import com.kuddy.common.member.exception.MemberNotFoundException;
+import com.kuddy.common.member.repository.MemberRepository;
+import com.kuddy.common.security.user.GoogleUserInfo;
+import com.kuddy.common.security.user.KakaoUserInfo;
+import com.kuddy.common.security.user.OAuth2UserInfo;
+import com.kuddy.common.security.user.PrincipalDetails;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+	private final MemberRepository memberRepository;
+
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		OAuth2User oAuth2User = super.loadUser(userRequest);
+		log.info("getAttributes : {}", oAuth2User.getAttributes());
+
+		OAuth2UserInfo oAuth2UserInfo = null;
+
+		String provider = userRequest.getClientRegistration().getRegistrationId();
+
+		if(provider.equals("google")) {
+			log.info("구글 로그인 요청");
+			oAuth2UserInfo = new GoogleUserInfo( oAuth2User.getAttributes() );
+		} else if(provider.equals("kakao")) {
+			log.info("카카오 로그인 요청");
+			oAuth2UserInfo = new KakaoUserInfo( oAuth2User.getAttributes() );
+		}
+
+		Member member = saveOrUpdate(oAuth2UserInfo);
+		return new PrincipalDetails(member, oAuth2User.getAttributes());
+
+	}
+
+	// 혹시 이미 저장된 정보라면, update 처리
+	private Member saveOrUpdate(OAuth2UserInfo oAuth2UserInfo) {
+		Member member = memberRepository.findByUsername(oAuth2UserInfo.getName())
+			.map(entity -> {
+				entity.updateMember(oAuth2UserInfo.getEmail());
+				return entity;
+			})
+			.orElseGet(() -> {
+				if (!memberRepository.existsByEmail(oAuth2UserInfo.getEmail())) {
+					return Member.builder()
+						.nickname(oAuth2UserInfo.getNickname())
+						.email(oAuth2UserInfo.getEmail())
+						.profileImageUrl(oAuth2UserInfo.getProfileImageUrl())
+						.username(oAuth2UserInfo.getName())
+						.providerType(oAuth2UserInfo.getProvider())
+						.roleType(RoleType.MEMBER)
+						.build();
+				} else {
+					return null;
+				}
+			});
+
+		if (member == null) {
+			member = memberRepository.findByEmail(oAuth2UserInfo.getEmail()).orElseThrow(MemberNotFoundException::new);
+			member.updateMember(oAuth2UserInfo.getEmail());
+			return member;
+		}
+
+		return memberRepository.save(member);
+	}
+
+
+
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/service/OAuth2AuthenticationFailureHandler.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/service/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,46 @@
+package com.kuddy.common.security.service;
+
+
+import static com.kuddy.common.security.repository.CookieAuthorizationRequestRepository.*;
+
+import java.io.IOException;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.kuddy.common.security.repository.CookieAuthorizationRequestRepository;
+import com.kuddy.common.util.CookieUtils;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+	private final CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws
+		IOException {
+		String targetUrl = CookieUtils.getCookie(request, REDIRECT_URL_PARAM_COOKIE_KEY)
+			.map(Cookie::getValue)
+			.orElse(("/"));
+
+		targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
+			.queryParam("token", "")
+			.queryParam("error", exception.getLocalizedMessage())
+			.build().toUriString();
+
+		cookieAuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+
+		getRedirectStrategy().sendRedirect(request, response, targetUrl);
+	}
+
+}
+

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/service/OAuth2AuthenticationSuccessHandler.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/service/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,140 @@
+package com.kuddy.common.security.service;
+
+import static com.kuddy.common.security.repository.CookieAuthorizationRequestRepository.*;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.kuddy.common.jwt.JwtProvider;
+import com.kuddy.common.member.domain.ProviderType;
+import com.kuddy.common.redis.RedisService;
+
+import com.kuddy.common.security.repository.CookieAuthorizationRequestRepository;
+import com.kuddy.common.security.user.GoogleUserInfo;
+import com.kuddy.common.security.user.KakaoUserInfo;
+import com.kuddy.common.util.CookieUtils;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+	private final JwtProvider jwtProvider;
+	private final RedisService redisService;
+	private final CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException {
+		OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+		Map<String, Object> attributes = oAuth2User.getAttributes();
+		OAuth2AuthenticationToken authToken = (OAuth2AuthenticationToken)authentication;
+
+		ProviderType providerType = ProviderType.valueOf(authToken.getAuthorizedClientRegistrationId().toUpperCase());
+
+		String email = "null";
+		if (providerType.equals(ProviderType.KAKAO)) {
+			KakaoUserInfo kakaoUserInfo = new KakaoUserInfo(attributes);
+			email = kakaoUserInfo.getEmail();
+			log.info("kakao");
+		}
+		else if(providerType.equals(ProviderType.GOOGLE)){
+			GoogleUserInfo googleUserInfo = new GoogleUserInfo(attributes);
+			email = googleUserInfo.getEmail();
+			log.info("google");
+		}
+		else {
+			Map<String, Object> providerData = (Map<String, Object>) attributes.get(providerType.name().toLowerCase());
+			if (providerData != null) {
+				email = providerData.get("email").toString();
+			} else {
+				// Handle the case where providerData is null
+			}
+		}
+
+
+		String targetUrl = determineTargetUrl(request, response, authentication);
+		log.info("targetUrl = " + targetUrl);
+
+		String url = makeRedirectUrl(email, targetUrl);
+
+		ResponseCookie responseCookie = generateRefreshTokenCookie(email);
+		response.setHeader("Set-Cookie", responseCookie.toString());
+		response.getWriter().write(url);
+
+
+		if (response.isCommitted()) {
+			logger.info("응답이 이미 커밋된 상태입니다. " + url + "로 리다이렉트하도록 바꿀 수 없습니다.");
+			return;
+		}
+		clearAuthenticationAttributes(request, response);
+		getRedirectStrategy().sendRedirect(request, response, url);
+	}
+
+
+	private String makeRedirectUrl(String email, String redirectUrl) {
+
+		if (redirectUrl.equals(getDefaultTargetUrl())) {
+			redirectUrl = "http://localhost:3000";
+		}
+		log.info(redirectUrl);
+
+		String accessToken = jwtProvider.generateAccessToken(email);
+		log.info(accessToken);
+
+		return UriComponentsBuilder.fromHttpUrl(redirectUrl)
+			.path("/oauth2/redirect")
+			.queryParam("accessToken", accessToken)
+			.queryParam("redirectUrl", redirectUrl)
+			.build()
+			.encode()
+			.toUriString();
+
+
+	}
+
+	@Override
+	protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+		Optional<String> redirectUrl = CookieUtils.getCookie(request, REDIRECT_URL_PARAM_COOKIE_KEY).map(Cookie::getValue);
+		String targetUrl = redirectUrl.orElse(getDefaultTargetUrl());
+		return UriComponentsBuilder.fromUriString(targetUrl)
+			.build().toUriString();
+	}
+
+	protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+		super.clearAuthenticationAttributes(request);
+		cookieAuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+	}
+
+	public ResponseCookie generateRefreshTokenCookie(String email) {
+		String refreshToken = jwtProvider.generateRefreshToken(email);
+		Long refreshTokenValidationMs = jwtProvider.getRefreshTokenValidationMs();
+
+		redisService.setData("RefreshToken:" + email, refreshToken, refreshTokenValidationMs);
+
+		return ResponseCookie.from("refreshToken", refreshToken)
+			.path("/") // 해당 경로 하위의 페이지에서만 쿠키 접근 허용. 모든 경로에서 접근 허용한다.
+			.domain(".dev-lr.com")
+			.maxAge(TimeUnit.MILLISECONDS.toSeconds(refreshTokenValidationMs)) // 쿠키 만료 시기(초). 없으면 브라우저 닫힐 때 제거
+			.secure(true) // HTTPS로 통신할 때만 쿠키가 전송된다.
+			.sameSite("None")
+			.httpOnly(true) // JS를 통한 쿠키 접근을 막아, XSS 공격 등을 방어하기 위한 옵션이다.
+			.build();
+	}
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/service/UserDetailsServcieImpl.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/service/UserDetailsServcieImpl.java
@@ -1,0 +1,29 @@
+package com.kuddy.common.security.service;
+
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.kuddy.common.member.domain.Member;
+import com.kuddy.common.member.domain.MemberAdapter;
+import com.kuddy.common.member.exception.MemberNotFoundException;
+import com.kuddy.common.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServcieImpl implements UserDetailsService {
+	private final MemberRepository memberRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+		Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+
+		// UserDetails를 반환한다.
+		return new MemberAdapter(member);
+	}
+
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/user/AuthUser.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/user/AuthUser.java
@@ -1,0 +1,15 @@
+package com.kuddy.common.security.user;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : member")
+public @interface AuthUser {
+
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/user/GoogleUserInfo.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/user/GoogleUserInfo.java
@@ -1,0 +1,64 @@
+package com.kuddy.common.security.user;
+
+import java.util.Map;
+
+import com.kuddy.common.member.domain.ProviderType;
+
+public class GoogleUserInfo implements OAuth2UserInfo {
+
+	public static final String REGISTRATION_ID = "google";
+
+	private static final String PROVIDER_ID = "sub";
+
+	private static final String EMAIL = "email";
+	private static final String PROFILE = "picture";
+
+	private Map<String, Object> attributes;
+
+	public GoogleUserInfo(Map<String, Object> attributes) {
+		this.attributes = attributes;
+	}
+
+	@Override
+	public String getProviderId() {
+		return attributes.get(PROVIDER_ID).toString();
+	}
+
+	@Override
+	public String getRegistrationId() {
+		return REGISTRATION_ID;
+	}
+
+	@Override
+	public String getEmail() {
+		return attributes.get(EMAIL).toString();
+	}
+
+	@Override
+	public String getNickname() {
+		String email = getEmail();
+		return email.substring(0, email.indexOf("@"));
+	}
+
+	@Override
+	public String getName() {
+		return REGISTRATION_ID + "_" + getProviderId();
+	}
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	@Override
+	public ProviderType getProvider() {
+		return ProviderType.GOOGLE;
+	}
+
+	@Override
+	public String getProfileImageUrl(){
+		return attributes.get(PROFILE).toString();
+	}
+
+
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/user/KakaoUserInfo.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/user/KakaoUserInfo.java
@@ -1,0 +1,67 @@
+package com.kuddy.common.security.user;
+
+import java.util.Map;
+
+import com.kuddy.common.member.domain.ProviderType;
+
+public class KakaoUserInfo implements OAuth2UserInfo{
+
+	public static final String REGISTRATION_ID = "kakao";
+
+	private static final String PROVIDER_ID = "id";
+	private static final String EMAIL = "email";
+	private static final String NICKNAME = "nickname";
+	private static final String PROFILE = "profile_image_url";
+
+	private static final String KEY = "kakao_account";
+
+	private final Map<String, Object> attributes;
+
+	public KakaoUserInfo(Map<String, Object> attributes) {
+		this.attributes = attributes;
+	}
+
+
+	@Override
+	public String getProviderId() {
+		return attributes.get(PROVIDER_ID).toString();
+	}
+	@Override
+	public String getRegistrationId() {
+		return REGISTRATION_ID;
+	}
+	@Override
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	@Override
+	public ProviderType getProvider() {
+		return ProviderType.KAKAO;
+	}
+
+	@Override
+	public String getEmail() {
+		Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get(KEY);
+		return kakaoAccount.get(EMAIL).toString();
+	}
+
+	@Override
+	public String getName() {
+		return REGISTRATION_ID + "_" + this.getProviderId();
+	}
+
+
+	public String getNickname() {
+		Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get(KEY);
+		Map<String, Object> kakaoProfile = (Map<String, Object>)kakaoAccount.get("profile");
+		return kakaoProfile.get(NICKNAME).toString();
+	}
+
+	@Override
+	public String getProfileImageUrl(){
+		Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get(KEY);
+		Map<String, Object> kakaoProfile = (Map<String, Object>)kakaoAccount.get("profile");
+		return kakaoProfile.get(PROFILE).toString();
+	}
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/user/OAuth2UserInfo.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/user/OAuth2UserInfo.java
@@ -1,0 +1,20 @@
+package com.kuddy.common.security.user;
+
+import java.util.Map;
+
+import com.kuddy.common.member.domain.ProviderType;
+
+public interface OAuth2UserInfo {
+	String getProviderId();
+
+	String getRegistrationId();
+
+	Map<String, Object> getAttributes();
+
+	ProviderType getProvider();
+	String getEmail();
+	String getNickname();
+	String getProfileImageUrl();
+
+	String getName();
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/security/user/PrincipalDetails.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/security/user/PrincipalDetails.java
@@ -1,0 +1,82 @@
+package com.kuddy.common.security.user;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import com.kuddy.common.member.domain.Member;
+
+public class PrincipalDetails implements UserDetails, OAuth2User {
+
+	private Member member;
+
+	public PrincipalDetails(Member member) {
+		this.member = member;
+	}
+
+	// 권한 관련 작업을 하기 위한 role return
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		Collection<GrantedAuthority> collections = new ArrayList<>();
+		collections.add(() -> member.getRoleType().name());
+		return collections;
+	}
+
+	// get Password 메서드
+	@Override
+	public String getPassword() {
+		return null;
+	}
+
+	// get Username 메서드 (생성한 User은 loginId 사용)
+	@Override
+	public String getUsername() {
+		return member.getUsername();
+	}
+
+	// 계정이 만료 되었는지 (true: 만료X)
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	// 계정이 잠겼는지 (true: 잠기지 않음)
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	// 비밀번호가 만료되었는지 (true: 만료X)
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	// 계정이 활성화(사용가능)인지 (true: 활성화)
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+
+	// OAuth 로그인
+	private Map<String, Object> attributes;
+
+	public PrincipalDetails(Member member, Map<String, Object> attributes) {
+		this.member = member;
+		this.attributes = attributes;
+	}
+
+	@Override
+	public String getName() {
+		return null;
+	}
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+}

--- a/kuddy-back/common/src/main/java/com/kuddy/common/util/CookieUtils.java
+++ b/kuddy-back/common/src/main/java/com/kuddy/common/util/CookieUtils.java
@@ -1,0 +1,58 @@
+package com.kuddy.common.util;
+
+
+import java.io.Serializable;
+import java.util.Base64;
+import java.util.Optional;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.util.SerializationUtils;
+
+public class CookieUtils {
+
+	public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null && cookies.length > 0) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals(name)) {
+					return Optional.of(cookie);
+				}
+			}
+		}
+		return Optional.empty();
+	}
+
+	public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+		Cookie cookie = new Cookie(name, value);
+		cookie.setPath("/");
+		cookie.setHttpOnly(true);
+		cookie.setMaxAge(maxAge);
+		response.addCookie(cookie);
+	}
+
+	public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null && cookies.length > 0) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals(name)) {
+					cookie.setValue("");
+					cookie.setPath("/");
+					cookie.setMaxAge(0);
+					response.addCookie(cookie);
+				}
+			}
+		}
+	}
+
+	public static String serialize(Object object) {
+		return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize((Serializable) object));
+	}
+
+	public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+		return cls.cast(SerializationUtils.deserialize(Base64.getUrlDecoder().decode(cookie.getValue())));
+	}
+
+}

--- a/kuddy-back/noti-server/src/main/java/com/kuddy/notiserver/NotiServerApplication.java
+++ b/kuddy-back/noti-server/src/main/java/com/kuddy/notiserver/NotiServerApplication.java
@@ -2,7 +2,9 @@ package com.kuddy.notiserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication(scanBasePackages = "com.kuddy")
 public class NotiServerApplication {
 


### PR DESCRIPTION
## 기능 명세
- [x] kakao key 발급
- [x] kakao 로그인 구현
- [x] google key 발급
- [x] google 로그인 구현
- [x] SecurityConfig와 이에 필요한 요소들을 구현
- [x] member 엔티티 구현
- [x] filter 내 예외 발생 시 처리하는 핸들러 구현
- [x] redis 설정

## 결과 

### [GET] oauth2/authorization/kakao
- [GET] oauth2/authorization/google
- 쿼리파라미터로 엑세스 토큰 전달


### [GET] api/v1/members/me
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "email": "ziyun1612@naver.com",
        "nickname": "권지윤",
        "profileImageUrl": "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg"
    }
}
```
- 형식이 잘못된 토큰일 경우 
```json
{
    "status": "UNAUTHORIZED",
    "errorCode": "C1004",
    "message": "토큰 타입이 올바르지 않습니다."
}
```

## 함께 의논할 점
- 원래 에러가 발생한 시간을 응답값에 넣으려고 했는데 localdate 타입의 문제로 오류가 생겨 일단 삭제했습니다. 
추후 필요하다면 다시 추가하겠습니다

close : #6 