### PR TITLE
[chore] pageInfo의 size 값을 수정한다.

### DIFF
--- a/api-server/src/main/java/com/kuddy/apiserver/spot/service/SpotService.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/spot/service/SpotService.java
@@ -111,12 +111,7 @@ public class SpotService {
             respone.add(spotResDto);
         }
 
-        //페이지가 1장일 경우 요소의 총 개수가 size
-        if (spotPage.getTotalPages() == 1) {
-            size = (int) spotPage.getTotalElements();
-        }
-
-        PageInfo pageInfo = new PageInfo(page, size, spotPage.getTotalElements(), spotPage.getTotalPages());
+        PageInfo pageInfo = new PageInfo(page, spotPage.getNumberOfElements(), spotPage.getTotalElements(), spotPage.getTotalPages());
         SpotPageResDto spotPageResDto = new SpotPageResDto(respone, pageInfo);
 
         return ResponseEntity.ok(StatusResponse.builder()


### PR DESCRIPTION
## 기능 명세
- [x] spot 기능에서 해당 페이지의 실제 원소 개수 반환하도록 수정

## 결과 
### [GET] api/v1/spots/district/{district}?page={page}&size={size}
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "spots": [
            {
                "id": 6,
                "name": "AMORE Spa (아모레퍼시픽 스파)",
                "contentId": 1295190,
                "district": "Gangnam",
                "category": "Attraction",
                "imageUrl": ""
            },
            {
                "id": 8,
                "name": "Apgujeong Rodeo Street (압구정 로데오거리)",
                "contentId": 264107,
                "district": "Gangnam",
                "category": "Attraction",
                "imageUrl": ""
            },
            {
                "id": 33,
                "name": "Baekam Art Hall (백암아트홀)",
                "contentId": 495665,
                "district": "Gangnam",
                "category": "Culture",
                "imageUrl": "http://tong.visitkorea.or.kr/cms/resource/91/1837291_image2_1.jpg"
            },
            {
                "id": 48,
                "name": "COEX Aquarium (코엑스 아쿠아리움)",
                "contentId": 736274,
                "district": "Gangnam",
                "category": "Culture",
                "imageUrl": ""
            },
            {
                "id": 49,
                "name": "COEX Artium (코엑스아티움)",
                "contentId": 1024886,
                "district": "Gangnam",
                "category": "Culture",
                "imageUrl": "http://tong.visitkorea.or.kr/cms/resource/72/2005272_image2_1.jpg"
            },
            {
                "id": 50,
                "name": "Convention and Exhibition Center (COEX) (한국종합무역센터(코엑스))",
                "contentId": 268208,
                "district": "Gangnam",
                "category": "Culture",
                "imageUrl": ""
            },
            {
                "id": 51,
                "name": "Coreana Art & Culture Complex (코리아나 화장박물관)",
                "contentId": 1000038,
                "district": "Gangnam",
                "category": "Culture",
                "imageUrl": "http://tong.visitkorea.or.kr/cms/resource/80/2564380_image2_1.jpg"
            },
            {
                "id": 57,
                "name": "Dosan Ahn Chang-Ho Memorial Hall (도산안창호 기념관)",
                "contentId": 1748357,
                "district": "Gangnam",
                "category": "Culture",
                "imageUrl": "http://tong.visitkorea.or.kr/cms/resource/68/1570768_image2_1.jpg"
            }
        ],
        "pageInfo": {
            "page": 1,
            "size": 8,
            "totalElements": 8,
            "totalPages": 1
        }
    }
}
```

## 함께 의논할 점
- 없음

close #39 