### PR TITLE
[fix] Spot 관련 api request 방식 수정

### DIFF
--- a/api-server/src/main/java/com/kuddy/apiserver/spot/controller/SpotController.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/spot/controller/SpotController.java
@@ -70,7 +70,7 @@ public class SpotController {
     }
 
     //장소 검색(키워드+카테고리+지역구 각각 필터 가능, 지역구는 다중선택)
-    @GetMapping("/search")
+    @PostMapping("/search")
     public ResponseEntity<StatusResponse> searchSpot(@RequestBody SpotSearchReqDto spotSearchReqDto, @RequestParam(value = "page") int page, @RequestParam(value = "size") int size) {
         //필터링 조건 없으면 전체 조회
         if (spotSearchReqDto.getKeyword().isEmpty() && spotSearchReqDto.getCategory().isEmpty() && spotSearchReqDto.getDistrict().isEmpty()) {

--- a/api-server/src/main/java/com/kuddy/apiserver/spot/controller/SpotController.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/spot/controller/SpotController.java
@@ -56,13 +56,12 @@ public class SpotController {
     }
 
     @GetMapping("/{contentId}")
-    public ResponseEntity<StatusResponse> getSpotDetail(@PathVariable Long contentId, @RequestParam(value = "x") double mapX, @RequestParam(value = "y") double mapY) {
+    public ResponseEntity<StatusResponse> getSpotDetail(@PathVariable Long contentId) {
         Spot spot = spotService.findSpotByContentId(contentId);
         Object commonDetail = tourApiService.getCommonDetail(spot);
         Object detailInfo = tourApiService.getDetailInfo(spot);
-        JSONObject nearbySpots = tourApiService.getLocationBasedApi(1, 5, mapX, mapY);
         JSONArray imageArr = tourApiService.getDetailImages(contentId);
-        return spotService.responseDetailInfo(commonDetail, detailInfo, nearbySpots, imageArr, spot);
+        return spotService.responseDetailInfo(commonDetail, detailInfo, imageArr, spot);
     }
 
     @GetMapping("/trend")

--- a/api-server/src/main/java/com/kuddy/apiserver/spot/controller/SpotController.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/spot/controller/SpotController.java
@@ -8,7 +8,6 @@ import com.kuddy.common.response.StatusResponse;
 import com.kuddy.common.spot.domain.Spot;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -51,7 +50,7 @@ public class SpotController {
     }
 
     @GetMapping("/recommendation")
-    public ResponseEntity<StatusResponse> recommendSpot(@RequestParam(value = "page") int page, @RequestParam(value = "x") double mapX, @RequestParam(value = "y") double mapY) {
+    public ResponseEntity<StatusResponse> recommendSpot(@RequestParam(value = "page") int page, @RequestParam(value = "x") String mapX, @RequestParam(value = "y") String mapY) {
         return spotService.changeJsonToResponse(tourApiService.getLocationBasedApi(page, 20, mapX, mapY));
     }
 

--- a/api-server/src/main/java/com/kuddy/apiserver/spot/dto/SpotDetailResDto.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/spot/dto/SpotDetailResDto.java
@@ -19,7 +19,8 @@ public class SpotDetailResDto {
     private String district;
     private String category;
     private Long heart;
-
+    private String mapX;
+    private String mapY;
     private String about;
     private String phoneNum;
     private String homepage;
@@ -37,6 +38,8 @@ public class SpotDetailResDto {
                 .district(spot.getDistrict().getArea())
                 .category(spot.getCategory().getType())
                 .heart(spot.getNumOfHearts())
+                .mapX(spot.getMapX())
+                .mapY(spot.getMapY())
                 .about(about)
                 .phoneNum(phoneNum)
                 .homepage(homepage)

--- a/api-server/src/main/java/com/kuddy/apiserver/spot/dto/SpotDetailResDto.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/spot/dto/SpotDetailResDto.java
@@ -26,14 +26,12 @@ public class SpotDetailResDto {
     private String location;
     private String post;
     private Object additionalInfo;
-    private List<SpotResDto> nearbyPlace;
     private List<String> imageList;
     private List<MemberResDto> kuddyList;
     private List<MemberResDto> travelerList;
 
-    public static SpotDetailResDto of(Spot spot, String about, String phoneNum, String homepage, String location, String post, Object additionalInfo, List<SpotResDto> nearbyPlace, List<String> imageList, List<MemberResDto> kuddyList, List<MemberResDto> travelerList){
+    public static SpotDetailResDto of(Spot spot, String about, String phoneNum, String homepage, String location, String post, Object additionalInfo, List<String> imageList, List<MemberResDto> kuddyList, List<MemberResDto> travelerList){
         return SpotDetailResDto.builder()
-//                .id(spot.getId())
                 .name(spot.getName())
                 .contentId(spot.getContentId())
                 .district(spot.getDistrict().getArea())
@@ -45,7 +43,6 @@ public class SpotDetailResDto {
                 .location(location)
                 .post(post)
                 .additionalInfo(additionalInfo)
-                .nearbyPlace(nearbyPlace)
                 .imageList(imageList)
                 .kuddyList(kuddyList)
                 .travelerList(travelerList)

--- a/api-server/src/main/java/com/kuddy/apiserver/spot/dto/SpotResDto.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/spot/dto/SpotResDto.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SpotResDto {
     private Long contentId;
     private String name;

--- a/api-server/src/main/java/com/kuddy/apiserver/spot/dto/SpotResDto.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/spot/dto/SpotResDto.java
@@ -27,6 +27,8 @@ public class SpotResDto {
                 .district(spot.getDistrict().getArea())
                 .category(spot.getCategory().getType())
                 .imageUrl(spot.getImageUrl())
+                .mapX(spot.getMapX())
+                .mapY(spot.getMapY())
                 .build();
     }
 }

--- a/api-server/src/main/java/com/kuddy/apiserver/spot/service/SpotService.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/spot/service/SpotService.java
@@ -66,6 +66,8 @@ public class SpotService {
                         .category(Category.valueOf(contentType))
                         .imageUrl((String) item.get("firstimage"))
                         .numOfHearts(0L)
+                        .mapX((String) item.get("mapx"))
+                        .mapY((String) item.get("mapy"))
                         .build());
             }
         }

--- a/api-server/src/main/java/com/kuddy/apiserver/spot/service/SpotService.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/spot/service/SpotService.java
@@ -14,6 +14,7 @@ import com.kuddy.common.response.StatusResponse;
 import com.kuddy.common.spot.domain.Category;
 import com.kuddy.common.spot.domain.District;
 import com.kuddy.common.spot.domain.Spot;
+import com.kuddy.common.spot.exception.NoSpotNearbyException;
 import com.kuddy.common.spot.repository.SpotRepository;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.JSONArray;
@@ -185,6 +186,8 @@ public class SpotService {
 
     //JSONObject에서 필요한 정보만 담아 List로 반환하는 반복적인 코드
     public List<SpotResDto> changeJsonBodyToList(JSONObject body) {
+        if(((String) body.get("items")).isEmpty())
+            throw new NoSpotNearbyException();
         JSONObject items = (JSONObject) body.get("items");
         JSONArray spotArr = (JSONArray) items.get("item");
 

--- a/api-server/src/main/java/com/kuddy/apiserver/spot/service/SpotService.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/spot/service/SpotService.java
@@ -186,7 +186,7 @@ public class SpotService {
 
     //JSONObject에서 필요한 정보만 담아 List로 반환하는 반복적인 코드
     public List<SpotResDto> changeJsonBodyToList(JSONObject body) {
-        if(((String) body.get("items")).isEmpty())
+        if(body.get("items").equals(""))
             throw new NoSpotNearbyException();
         JSONObject items = (JSONObject) body.get("items");
         JSONArray spotArr = (JSONArray) items.get("item");

--- a/api-server/src/main/java/com/kuddy/apiserver/spot/service/SpotService.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/spot/service/SpotService.java
@@ -135,10 +135,7 @@ public class SpotService {
     }
 
     //각 관광지 상세 정보 조회(사진 여러장 + 찜한 멤버들 + 위치기반추천)
-    public ResponseEntity<StatusResponse> responseDetailInfo(Object commonDetail, Object detailInfo, JSONObject nearbySpots, JSONArray imageArr, Spot spot) {
-
-        //위치 기반 관광지 추천(5개)
-        List<SpotResDto> recommendationList = changeJsonBodyToList(nearbySpots);
+    public ResponseEntity<StatusResponse> responseDetailInfo(Object commonDetail, Object detailInfo, JSONArray imageArr, Spot spot) {
 
         //찜한 멤버들
         List<MemberResDto> kuddyList = new ArrayList<>();
@@ -171,7 +168,7 @@ public class SpotService {
         JSONObject item = (JSONObject) commonDetail;
         SpotDetailResDto spotDetailResDto = SpotDetailResDto.of(spot, (String) item.get("overview"), (String) item.get("tel"),
                 (String) item.get("homepage"), (String) item.get("addr1"), (String) item.get("zipcode"), (Object) additionalInfo,
-                recommendationList, imageList, kuddyList, travelerList);
+                imageList, kuddyList, travelerList);
 
         return returnStatusResponse(spotDetailResDto);
     }

--- a/api-server/src/main/java/com/kuddy/apiserver/spot/service/TourApiService.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/spot/service/TourApiService.java
@@ -47,7 +47,7 @@ public class TourApiService {
     }
 
     //현재 위치 기반으로 2km 반경 관광지 20개씩 조회
-    public JSONObject getLocationBasedApi(int page, int size, double mapX, double mapY) {
+    public JSONObject getLocationBasedApi(int page, int size, String mapX, String mapY) {
 
         try {
             URL url = new URL(BASE_URL + "locationBasedList1?numOfRows=" +

--- a/common/src/main/java/com/kuddy/common/exception/type/ExceptionType.java
+++ b/common/src/main/java/com/kuddy/common/exception/type/ExceptionType.java
@@ -47,6 +47,7 @@ import com.kuddy.common.security.exception.InvalidRefreshTokenException;
 import com.kuddy.common.security.exception.InvalidTokenException;
 import com.kuddy.common.security.exception.InvalidTokenTypeException;
 import com.kuddy.common.security.exception.UnAuthorizedTokenException;
+import com.kuddy.common.spot.exception.NoSpotNearbyException;
 import com.kuddy.common.spot.exception.SpotNotFoundException;
 import com.kuddy.common.spot.exception.TourApiExeption;
 import com.kuddy.common.ticket.exception.OnlyTravelerRequestException;
@@ -89,6 +90,7 @@ public enum ExceptionType {
 	HEART_NOT_FOUND_EXCEPTION("C4002", "해당 관광지에 대한 찜 정보를 찾을 수 없습니다.", HeartNotFoundException.class),
 	ALREADY_LIKED_EXCEPTION("C4003", "이미 찜한 관광지입니다.", AlreadyLikedException.class),
 	NO_SPOT_EXISTS_EXCEPTION("C4004", "존재하지 않는 spot id입니다.", NoSpotExists.class),
+	NO_SPOT_NEARBY_EXCEPTION("C4005", "주변에 관광지가 없습니다.", NoSpotNearbyException.class),
 
 	//회원 관련 - C2***
 	INVALID_NICKNAME_EXCEPTION("C2000", "유효하지 않은 닉네임입니다.", InvalidNicknameException.class),

--- a/common/src/main/java/com/kuddy/common/spot/domain/Spot.java
+++ b/common/src/main/java/com/kuddy/common/spot/domain/Spot.java
@@ -36,14 +36,22 @@ public class Spot {
     @Column(nullable = false)
     private Long numOfHearts;
 
+    @Column(nullable = false, length = 20)
+    private String mapX;
+
+    @Column(nullable = false, length = 20)
+    private String mapY;
+
     @Builder
-    public Spot(String name, Long contentId, District district, String imageUrl, Category category, Long numOfHearts) {
+    public Spot(String name, Long contentId, District district, String imageUrl, Category category, Long numOfHearts, String mapX, String mapY) {
         this.name= name;
         this.contentId = contentId;
         this.district = district;
         this.category = category;
         this.imageUrl = imageUrl;
         this.numOfHearts = numOfHearts;
+        this.mapX = mapX;
+        this.mapY = mapY;
     }
 
     public void likeSpot() {

--- a/common/src/main/java/com/kuddy/common/spot/exception/NoSpotNearbyException.java
+++ b/common/src/main/java/com/kuddy/common/spot/exception/NoSpotNearbyException.java
@@ -1,0 +1,6 @@
+package com.kuddy.common.spot.exception;
+
+import com.kuddy.common.exception.custom.BadRequestException;
+
+public class NoSpotNearbyException extends BadRequestException {
+}


### PR DESCRIPTION
## 기능 명세
- [x] spot 상세 조회 요청 시 param으로 x, y 좌표 안보내도록 수정
- [x] spot 검색 GET -> POST
- [x] spot db에 x, y 좌표값도 저장하도록 수정
- [x] spot 검색 반환값에 좌표값 추가
- [x] spot 위치 기반 추천에서 관광지 없을 경우 예외처리

## 결과 
### [GET] /api/v1/spots/search?page=1&size=20
- x, y 좌표값 추가
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "spots": [
            {
                "contentId": 264111,
                "name": "Archaeological Site in Amsa-dong, Seoul (서울 암사동 유적)",
                "district": "Gangdong",
                "category": "Attraction",
                "imageUrl": "http://tong.visitkorea.or.kr/cms/resource/19/204019_image2_1.jpg",
                "mapX": "127.1309239757",
                "mapY": "37.5605132450"
            },
            {
                "contentId": 1684868,
                "name": "Bonghwasan Mountain - Seoul (봉화산 (서울))",
                "district": "Jungnang",
                "category": "Attraction",
                "imageUrl": "http://tong.visitkorea.or.kr/cms/resource/36/1894536_image2_1.jpg",
                "mapX": "127.0866155277",
                "mapY": "37.6086568514"
            }
        ],
        "pageInfo": {
            "page": 1,
            "size": 2,
            "totalElements": 2,
            "totalPages": 1
        }
    }
}
```

### [GET] /api/v1/spots/recommendation?page=1&x=126.9472863&y=37.5615351
- 주변에 추천 관광지 없을 경우 예외처리 추가
```json
{
    "status": "BAD_REQUEST",
    "errorCode": "C4005",
    "message": "주변에 관광지가 없습니다."
}
```

## 함께 의논할 점
- 없음