### PR TITLE
[chore] 프로필 정보 조회시, email도 추가

### DIFF
--- a/api-server/src/main/java/com/kuddy/apiserver/profile/dto/response/ProfileResDto.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/profile/dto/response/ProfileResDto.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.kuddy.apiserver.member.dto.MemberResDto;
 import com.kuddy.common.member.domain.Member;
 import com.kuddy.common.member.domain.RoleType;
 import com.kuddy.common.profile.domain.GenderType;
@@ -24,11 +25,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ProfileResDto {
-	private Long memberId;
+	private MemberResDto memberInfo;
 	private String role;
 	private String introduce;
-	private String nickname;
-	private String profileImage;
 	private GenderType gender;
 	private Integer age;
 	private String temperament;
@@ -64,10 +63,8 @@ public class ProfileResDto {
 		}
 
 		return ProfileResDto.builder()
-			.memberId(member.getId())
 			.role(member.getRoleType().getDisplayName())
-			.nickname(member.getNickname())
-			.profileImage(member.getProfileImageUrl())
+			.memberInfo(MemberResDto.of(member))
 			.introduce(profile.getIntroduce())
 			.age(profile.getAge())
 			.gender(profile.getGenderType())

--- a/api-server/src/main/java/com/kuddy/apiserver/profile/dto/response/ProfileSearchResDto.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/profile/dto/response/ProfileSearchResDto.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.kuddy.apiserver.member.dto.MemberResDto;
 import com.kuddy.common.member.domain.Member;
 import com.kuddy.common.member.domain.RoleType;
 import com.kuddy.common.profile.domain.GenderType;
@@ -24,11 +25,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ProfileSearchResDto {
-	private Long memberId;
+	private MemberResDto memberInfo;
 	private String role;
 	private String introduce;
-	private String nickname;
-	private String profileImage;
 	private GenderType gender;
 	private Integer age;
 	private String temperament;
@@ -69,10 +68,8 @@ public class ProfileSearchResDto {
 		}
 
 		return ProfileSearchResDto.builder()
-			.memberId(member.getId())
+			.memberInfo(MemberResDto.of(member))
 			.role(member.getRoleType().getDisplayName())
-			.nickname(member.getNickname())
-			.profileImage(member.getProfileImageUrl())
 			.introduce(profile.getIntroduce())
 			.age(profile.getAge())
 			.gender(profile.getGenderType())


### PR DESCRIPTION
## 기능 명세
- [x] 프론트 요청으로 프로필 정보 조회시 멤버의 기본 정보도 모두 응답하도록 수정

## 결과 
- [GET] api/v1/members/profile
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "memberInfo": {
            "memberId": 1,
            "email": "ziyun1612@ewhain.net",
            "nickname": "kuku",
            "profileImageUrl": "imageurl.com"
        },
        "role": "TRAVELER",
        "gender": "MR",
        "age": 30,
        "temperament": "Introvert",
        "decisionMaking": "Judging",
        "interests": {
            "activitiesInvestmentTech": [
                "NOT_SELECTED"
            ],
            "artBeauty": [
                "FASHION"
            ],
            "careerMajor": [
                "NOT_SELECTED"
            ],
            "lifestyle": [
                "CAT_BUTLER"
            ],
            "entertainment": [
                "NETFLIX"
            ],
            "food": [
                "DESSERT"
            ],
            "hobbiesInterests": [
                "READING",
                "SHOPPING"
            ],
            "sports": [
                "BASKETBALL",
                "SKI"
            ],
            "wellbeing": [
                "HEALTH",
                "VEGAN"
            ]
        },
        "nationality": "USA",
        "languages": [
            {
                "languageType": "English",
                "languageLevel": 5
            },
            {
                "languageType": "Spanish",
                "languageLevel": 4
            }
        ],
        "areas": [
            {
                "areaName": "Nowon"
            },
            {
                "areaName": "Songpa"
            }
        ],
        "ticketStatus": "Not Submitted"
    }
}
```

## 함께 의논할 점
> - 없으면 생략 