### PR TITLE
[chore] profile 생성 시 introduce 빈문자열로 초기화

### DIFF
--- a/api-server/src/main/java/com/kuddy/apiserver/profile/dto/request/ProfileReqDto.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/profile/dto/request/ProfileReqDto.java
@@ -55,6 +55,7 @@ public class ProfileReqDto {
 				.nationality(nationality)
 				.temperament(temperament)
 				.decisionMaking(decisionMaking)
+				.introduce("")
 				.build();
 		}
 	}

--- a/common/src/main/java/com/kuddy/common/profile/domain/Profile.java
+++ b/common/src/main/java/com/kuddy/common/profile/domain/Profile.java
@@ -137,7 +137,7 @@ public class Profile extends BaseTimeEntity {
 	@Builder
 	public Profile(String job, Integer age, String nationality,
 		DecisionMaking decisionMaking,
-		Temperament temperament, GenderType genderType, Member member) {
+		Temperament temperament, GenderType genderType, Member member, String introduce) {
 		this.job = job;
 		this.age = age;
 		this.kuddyLevel = KuddyLevel.NOT_KUDDY;
@@ -147,6 +147,7 @@ public class Profile extends BaseTimeEntity {
 		this.genderType = genderType;
 		this.member = member;
 		this.ticketStatus = TicketStatus.NOT_SUBMITTED;
+		this.introduce = introduce;
 	}
 
 	public void changeJob(String newJob) {


### PR DESCRIPTION


## 기능 명세
- [x] 프론트 요청으로 profile 생성 시 introduce의 값을 null이 아닌 빈문자열로 초기화하도록 수정

## 결과 
### [POST] /api/v1/members/profile 의 로직 수정

## 함께 의논할 점
> - 없으면 생략 