### PR TITLE
[hotfix] Profile id의 member 정보로 응답하도록 변경

### DIFF
--- a/api-server/src/main/java/com/kuddy/apiserver/profile/controller/MemberProfileController.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/profile/controller/MemberProfileController.java
@@ -54,7 +54,7 @@ public class MemberProfileController {
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<StatusResponse> readProfile(@AuthUser Member member, @PathVariable Long profileId) {
 		Profile profile = profileService.findById(profileId);
-		ProfileSearchResDto response = ProfileSearchResDto.from(member, profile);
+		ProfileSearchResDto response = ProfileSearchResDto.from(profile.getMember(), profile);
 		return ResponseEntity.ok(StatusResponse.builder()
 			.status(StatusEnum.OK.getStatusCode())
 			.message(StatusEnum.OK.getCode())


### PR DESCRIPTION
## 기능 명세
- [x] 로그인한 member의 정보가 응답으로 가는 것을 profile id 주인의 정보로 응답하도록 수정

## 결과 


## 함께 의논할 점
> - 없으면 생략 