### PR TITLE
[hotfix] spot 테이블 이름 대소문자 수정

### DIFF
--- a/common/src/main/java/com/kuddy/common/spot/repository/SpotRepository.java
+++ b/common/src/main/java/com/kuddy/common/spot/repository/SpotRepository.java
@@ -22,9 +22,9 @@ public interface SpotRepository extends JpaRepository<Spot, Long>, JpaSpecificat
     List<Spot> findAllByContentIdIn(List<Long> contentIds);
 
     String HAVERSINE_FORMULA = "(6371 * acos(cos(radians(:mapY)) * cos(radians(s.mapY)) * cos(radians(s.mapX) - radians(:mapX)) + sin(radians(:mapY)) * sin(radians(s.mapY))))";
-    @Query(value = "SELECT * FROM Spot s WHERE " + HAVERSINE_FORMULA + " <= 2 AND s.category IN ('Attraction', 'Culture', 'Restaurant', 'Festival') ORDER BY "+ HAVERSINE_FORMULA + " ASC", nativeQuery = true)
+    @Query(value = "SELECT * FROM spot s WHERE " + HAVERSINE_FORMULA + " <= 2 AND s.category IN ('Attraction', 'Culture', 'Restaurant', 'Festival') ORDER BY "+ HAVERSINE_FORMULA + " ASC", nativeQuery = true)
     List<Spot> findAllByDistance(String mapX, String mapY);
 
-    @Query(value = "SELECT * FROM Spot s WHERE " + HAVERSINE_FORMULA + " <= 2 AND s.content_id NOT IN (:contentId) AND s.category IN ('Attraction', 'Culture', 'Restaurant', 'Festival') ORDER BY "+ HAVERSINE_FORMULA + " ASC LIMIT 5", nativeQuery = true)
+    @Query(value = "SELECT * FROM spot s WHERE " + HAVERSINE_FORMULA + " <= 2 AND s.content_id NOT IN (:contentId) AND s.category IN ('Attraction', 'Culture', 'Restaurant', 'Festival') ORDER BY "+ HAVERSINE_FORMULA + " ASC LIMIT 5", nativeQuery = true)
     List<Spot> findTop5ByDistance(Long contentId, String mapX, String mapY);
 }


### PR DESCRIPTION
## 기능 명세
- [x] 위치 기반 spot 조회 시 mysql 쿼리의 테이블 이름 대소문자 수정


## 결과 
### [GET] /api/v1/spots/recommendation/{contentId}?&x={mapX}&y={mapY}
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": [
        {
            "contentId": 1351623,
            "name": "Ewha Womans University Museum (이화여자대학교박물관)",
            "district": "Seodaemun",
            "category": "Culture",
            "imageUrl": "http://tong.visitkorea.or.kr/cms/resource/49/2390749_image2_1.JPG",
            "mapX": "126.9465962863",
            "mapY": "37.5617625629"
        },
        {
            "contentId": 2992566,
            "name": "Ewha Womans University (이화여자대학교)",
            "district": "Seodaemun",
            "category": "Culture",
            "imageUrl": "",
            "mapX": "126.9456964364",
            "mapY": "37.5593378282"
        },
        {
            "contentId": 2700415,
            "name": "Bulbap(불밥)",
            "district": "Seodaemun",
            "category": "Restaurant",
            "imageUrl": "http://tong.visitkorea.or.kr/cms/resource/73/2684773_image2_1.jpg",
            "mapX": "126.9464186055",
            "mapY": "37.5589101133"
        },
        {
            "contentId": 2695911,
            "name": "Gami Bunsik (가미분식)",
            "district": "Seodaemun",
            "category": "Restaurant",
            "imageUrl": "http://tong.visitkorea.or.kr/cms/resource/85/2684785_image2_1.jpg",
            "mapX": "126.9459519870",
            "mapY": "37.5587101279"
        },
        {
            "contentId": 2699978,
            "name": "Raintree (레인트리)",
            "district": "Seodaemun",
            "category": "Restaurant",
            "imageUrl": "http://tong.visitkorea.or.kr/cms/resource/61/2702561_image2_1.JPG",
            "mapX": "126.9462797395",
            "mapY": "37.5585490414"
        }
    ]
}
```

## 함께 의논할 점
> - 없으면 생략 
