### PR TITLE
[hotfix] meetup의 주인인지 확인하는 로직 변경

### DIFF
--- a/chat-server/src/main/java/com/kuddy/chatserver/chat/service/MeetupStatusService.java
+++ b/chat-server/src/main/java/com/kuddy/chatserver/chat/service/MeetupStatusService.java
@@ -43,7 +43,7 @@ public class MeetupStatusService {
 		return meetup;
 	}
 	public void validateMember(Member member, Meetup meetup){
-		if(meetup.getKuddy().equals(member) || meetup.getTraveler().equals(member)){
+		if(!meetup.getKuddy().getId().equals(member.getId()) && !meetup.getTraveler().getId().equals(member.getId())){
 			throw new NotAuthorException();
 		}
 	}


### PR DESCRIPTION
## 기능 명세
- [x] member의 id와 동행의 주인의 id를 비교하는 로직으로 변경

## 결과 


## 함께 의논할 점
> - 없으면 생략 