### PR TITLE
[feature] 프로필 취향 검색에 role 필터링 추가한다. 

### DIFF
--- a/api-server/src/main/java/com/kuddy/apiserver/profile/controller/ProfileSearchController.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/profile/controller/ProfileSearchController.java
@@ -74,13 +74,9 @@ public class ProfileSearchController {
 
 	@PostMapping("/search")
 	public ResponseEntity<StatusResponse> searchProfileInfo(
-		@RequestBody final ProfileSearchReqDto reqDto) {
-		List<Profile> profileList = profileQueryService.findProfilesBySearchCriteria(reqDto);
-		ProfileSearchListResDto response = ProfileSearchListResDto.from(profileList, reqDto.getInterestContent());
-		return ResponseEntity.ok(StatusResponse.builder()
-			.status(StatusEnum.OK.getStatusCode())
-			.message(StatusEnum.OK.getCode())
-			.data(response)
-			.build());
+			@RequestParam(value = "page") int page, @RequestParam(value = "size") int size,
+			@RequestBody final ProfileSearchReqDto reqDto) {
+		Page<Profile> profileList = profileQueryService.findProfilesBySearchCriteria(page, size, reqDto);
+		return profileService.changePageToResponse(profileList, page, size);
 	}
 }

--- a/api-server/src/main/java/com/kuddy/apiserver/profile/dto/request/ProfileSearchReqDto.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/profile/dto/request/ProfileSearchReqDto.java
@@ -14,5 +14,6 @@ public class ProfileSearchReqDto {
 	private String interestGroup;
 	private String interestContent;
 	private String nickname;
+	private String role;
 
 }

--- a/common/src/main/java/com/kuddy/common/member/domain/RoleType.java
+++ b/common/src/main/java/com/kuddy/common/member/domain/RoleType.java
@@ -25,4 +25,15 @@ public enum RoleType {
 			.findAny()
 			.orElse(GUEST);
 	}
+	public static RoleType fromString(String roleString) {
+		if (roleString == null || roleString.trim().isEmpty()) {
+			return null;
+		}
+
+		try {
+			return RoleType.valueOf(roleString.toUpperCase().trim());
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
+	}
 }


### PR DESCRIPTION
## 기능 명세
- [x] 프로필 취향 검색에 role 필터링 추가

## 결과 
- [GET] api/v1/profiles/search?page=1&size=2
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "profileList": [
            {
                "profileId": 7,
                "memberId": 7,
                "role": "KUDDY",
                "nickname": "ewha",
                "profileImage": "https://kuddy-bucket.s3.ap-northeast-2.amazonaws.com/c83913d6-03eb-4667-941e-03bf9e791ebcplz.jpg",
                "kuddyLevel": "EXPLORER",
                "seletedInterests": [
                    "PICTURE"
                ]
            },
            {
                "profileId": 2,
                "memberId": 1,
                "role": "KUDDY",
                "introduce": "hi",
                "nickname": "happy",
                "profileImage": "imageurl.com",
                "kuddyLevel": "SOULMATE",
                "seletedInterests": [
                    "NETFLIX",
                    "HEALTH",
                    "SHOPPING"
                ]
            }
        ],
        "pageInfo": {
            "page": 1,
            "size": 2,
            "totalElements": 30,
            "totalPages": 15
        }
    }
}
```

## 함께 의논할 점
> - 없으면 생략 
#111 