### PR TITLE
refactor : 일정 생성/삭제 기능을 비동기 이벤트로 분리

### DIFF
--- a/api-server/src/main/java/com/kuddy/apiserver/meetup/MeetUpPayedEventListener.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/meetup/MeetUpPayedEventListener.java
@@ -1,16 +1,17 @@
 package com.kuddy.apiserver.meetup;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.kuddy.apiserver.notification.service.MailNotiService;
-import com.kuddy.common.meetup.service.CalendarEventService;
+import com.kuddy.common.meetup.service.CalendarEventFacade;
 import com.kuddy.common.meetup.service.MeetupService;
 import com.kuddy.common.member.domain.Member;
-import com.kuddy.common.member.repository.MemberRepository;
 import com.kuddy.common.notification.calendar.domain.Calendar;
 import com.kuddy.common.notification.calendar.repository.CalendarRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -19,23 +20,29 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class MeetUpPayedEventListener {
-    private final CalendarEventService calendarEventService;
+    private final CalendarEventFacade calendarEventFacade;
     private final CalendarRepository calendarRepository;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, classes = MeetupService.MeetupPayedEvent.class)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleMeetupPayedEvent(MeetupService.MeetupPayedEvent event) throws IOException {
-        Member kuddy = event.getMeetup().getKuddy();
-        Member traveler = event.getMeetup().getTraveler();
-        calendarEventService.createCalendarEvent(kuddy, event.getMeetup());
-        calendarEventService.createCalendarEvent(traveler, event.getMeetup());
+        Long kuddyId = event.getKuddyId();
+        Long travelerId = event.getTravelerId();
+        log.info("kuddy id  :  " + String.valueOf(kuddyId));
+        log.info("traveler id  :  " + String.valueOf(travelerId));
+
+        calendarEventFacade.createCalendarEvent(kuddyId, event.getMeetup(), event.getSpotName());
+        calendarEventFacade.createCalendarEvent(travelerId, event.getMeetup(), event.getSpotName());
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, classes = MeetupService.MeetupCanceledEvent.class)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleMeetupCanceledEvent(MeetupService.MeetupCanceledEvent event) throws JsonProcessingException {
         List<Calendar> eventList = calendarRepository.findAllByMeetup_Id(event.getMeetup().getId());
-        calendarEventService.deleteEvents(eventList);
+        calendarEventFacade.deleteEvents(eventList);
     }
 }

--- a/api-server/src/main/java/com/kuddy/apiserver/notification/NotiController.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/notification/NotiController.java
@@ -3,7 +3,10 @@ package com.kuddy.apiserver.notification;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.kuddy.apiserver.notification.service.MailNotiService;
 import com.kuddy.common.meetup.domain.Meetup;
+import com.kuddy.common.meetup.domain.MeetupStatus;
+import com.kuddy.common.meetup.exception.MeetupNotFoundException;
 import com.kuddy.common.meetup.repository.MeetupRepository;
+import com.kuddy.common.meetup.service.MeetupService;
 import com.kuddy.common.member.domain.Member;
 import com.kuddy.common.member.domain.ProviderType;
 import com.kuddy.common.notification.calendar.domain.Calendar;
@@ -14,6 +17,7 @@ import com.kuddy.common.response.StatusResponse;
 import com.kuddy.common.security.user.AuthUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,6 +35,8 @@ public class NotiController {
     private final CalendarRepository calendarRepository;
     private final GoogleCalendarService googleCalendarService;
     private final MailNotiService mailNotiService;
+    private final MeetupService meetupService;
+    private ApplicationEventPublisher eventPublisher;
 
 //    @PostMapping("/{chatId}")
 //    public void createEvent(@AuthUser Member member, @PathVariable String chatId) throws JsonProcessingException {
@@ -70,6 +76,21 @@ public class NotiController {
 //    @PostMapping("/email")
 //    public void sendMail() throws MessagingException {
 //        mailNotiService.sendReviewRequestEmail();
+//    }
+
+//    @PostMapping("/{meetupId}")
+//    public String acceptMeetup(@PathVariable Long meetupId){
+//        String newMeetupStatus = "PAYED";
+//        meetupService.updateMeetupTest(meetupId, newMeetupStatus);
+//
+//        return "일정 등록 완료";
+//    }
+//
+//    @DeleteMapping("/{meetupId}")
+//    public String deleteMeetup(@PathVariable Long meetupId){
+//        String newMeetupStatus = "KUDDY_CANCEL";
+//        meetupService.updateMeetupTest(meetupId, newMeetupStatus);
+//        return "일정 삭제 완료";
 //    }
 
 }

--- a/common/src/main/java/com/kuddy/common/meetup/service/CalendarEventFacade.java
+++ b/common/src/main/java/com/kuddy/common/meetup/service/CalendarEventFacade.java
@@ -4,26 +4,35 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.kuddy.common.meetup.domain.Meetup;
 import com.kuddy.common.member.domain.Member;
 import com.kuddy.common.member.domain.ProviderType;
+import com.kuddy.common.member.exception.MemberNotFoundException;
+import com.kuddy.common.member.repository.MemberRepository;
 import com.kuddy.common.notification.calendar.domain.Calendar;
 import com.kuddy.common.notification.calendar.service.GoogleCalendarService;
 import com.kuddy.common.notification.calendar.service.KakaoCalendarService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class CalendarEventService {
+@Transactional
+@Slf4j
+public class CalendarEventFacade {
     private final KakaoCalendarService kakaoCalendarService;
     private final GoogleCalendarService googleCalendarService;
+    private final MemberRepository memberRepository;
 
-    public void createCalendarEvent(Member member, Meetup meetup) throws IOException {
+    public void createCalendarEvent(Long memberId, Meetup meetup, String spotName) throws IOException {
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        log.info("member 소셜 :" + member.getProviderType());
         if (member.getProviderType().equals(ProviderType.KAKAO)) {
-            kakaoCalendarService.createKakaoEvent(member, meetup);
+            kakaoCalendarService.createKakaoEvent(member, meetup, spotName);
         } else {
-            googleCalendarService.createGoogleEvent(member, meetup);
+            googleCalendarService.createGoogleEvent(member, meetup, spotName);
         }
     }
 

--- a/common/src/main/java/com/kuddy/common/notification/calendar/dto/GoogleEvent.java
+++ b/common/src/main/java/com/kuddy/common/notification/calendar/dto/GoogleEvent.java
@@ -1,6 +1,7 @@
 package com.kuddy.common.notification.calendar.dto;
 
 import com.kuddy.common.meetup.domain.Meetup;
+import com.kuddy.common.spot.domain.Spot;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -52,7 +53,7 @@ public class GoogleEvent {
         this.reminders = reminders;
     }
 
-    public static GoogleEvent from(Meetup meetup){
+    public static GoogleEvent from(Meetup meetup, String spotName){
         LocalDateTime dateTime = meetup.getAppointment();
         ZoneId koreaZone = ZoneId.of("Asia/Seoul");
 
@@ -93,7 +94,7 @@ public class GoogleEvent {
         return GoogleEvent.builder()
                 .end(end)
                 .start(start)
-                .location(meetup.getSpot().getName())
+                .location(spotName)
                 .summary("Meet up")
                 .reminders(reminders)
                 .build();

--- a/common/src/main/java/com/kuddy/common/notification/calendar/dto/KakaoEvent.java
+++ b/common/src/main/java/com/kuddy/common/notification/calendar/dto/KakaoEvent.java
@@ -45,19 +45,23 @@ public class KakaoEvent {
         this.reminders = reminders;
     }
 
-    public static KakaoEvent from(Meetup meetup) {
-        Spot spot = meetup.getSpot();
-
+    public static KakaoEvent from(Meetup meetup, String spotName) {
         LocalDateTime dateTime = meetup.getAppointment();
         int minute = dateTime.getMinute();
         int remainder = minute % 5; // The minimum unit of start_at is 5 minutes
         LocalDateTime adjustedDateTime = dateTime.minusMinutes(remainder);
-        String startIsoString = adjustedDateTime
+        ZoneId koreaZone = ZoneId.of("Asia/Seoul");
+        ZonedDateTime zonedDateTime = adjustedDateTime.atZone(koreaZone);
+        ZonedDateTime endOfTheDay = zonedDateTime
+                .plusDays(1)
+                .truncatedTo(ChronoUnit.DAYS);
+
+        String startIsoString = zonedDateTime
+                .toInstant()
                 .atOffset(ZoneOffset.UTC)
                 .format(DateTimeFormatter.ISO_INSTANT);
-        LocalDateTime endOfTheDay = adjustedDateTime.toLocalDate().plusDays(1).atStartOfDay();
         String endIsoString = endOfTheDay
-                .truncatedTo(ChronoUnit.DAYS)
+                .toInstant()
                 .atOffset(ZoneOffset.UTC)
                 .format(DateTimeFormatter.ISO_INSTANT);
 
@@ -70,7 +74,7 @@ public class KakaoEvent {
                 .build();
 
         Location location = Location.builder()
-                .name(meetup.getSpot().getName())
+                .name(spotName)
                 .build();
 
         int[] reminders = {1440};  // 동행 하루 전 알림

--- a/common/src/main/java/com/kuddy/common/notification/calendar/service/GoogleCalendarService.java
+++ b/common/src/main/java/com/kuddy/common/notification/calendar/service/GoogleCalendarService.java
@@ -12,12 +12,14 @@ import com.kuddy.common.notification.calendar.dto.GoogleEvent;
 import com.kuddy.common.notification.calendar.repository.CalendarRepository;
 import com.kuddy.common.notification.exception.GoogleCalendarAPIException;
 import com.kuddy.common.redis.RedisService;
+import com.kuddy.common.spot.domain.Spot;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.DefaultUriBuilderFactory;
@@ -28,6 +30,7 @@ import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 @Slf4j
 public class GoogleCalendarService {
     private final GoogleAuthService googleAuthService;
@@ -56,10 +59,10 @@ public class GoogleCalendarService {
         }
     }
 
-    public void createGoogleEvent(Member member, Meetup meetup) throws IOException {
+    public void createGoogleEvent(Member member, Meetup meetup, String spotName) throws IOException {
         String googleAccessToken = verifyAndRefreshGoogleToken(member.getEmail());
 
-        GoogleEvent googleEvent = GoogleEvent.from(meetup);
+        GoogleEvent googleEvent = GoogleEvent.from(meetup, spotName);
         ObjectMapper objectMapper = new ObjectMapper();
         String googleEventString = objectMapper.writeValueAsString(googleEvent);
         log.info(String.valueOf(BodyInserters.fromValue(googleEvent)));

--- a/common/src/main/java/com/kuddy/common/notification/calendar/service/KakaoCalendarService.java
+++ b/common/src/main/java/com/kuddy/common/notification/calendar/service/KakaoCalendarService.java
@@ -11,6 +11,7 @@ import com.kuddy.common.notification.calendar.domain.Calendar;
 import com.kuddy.common.notification.calendar.repository.CalendarRepository;
 import com.kuddy.common.notification.exception.KakaoCalendarAPIException;
 import com.kuddy.common.redis.RedisService;
+import com.kuddy.common.spot.domain.Spot;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -18,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -32,6 +34,7 @@ import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 @Slf4j
 public class KakaoCalendarService {
     private final KakaoAuthService kakaoAuthService;
@@ -59,10 +62,10 @@ public class KakaoCalendarService {
     }
 
     // 카카오 일반 일정 생성
-    public void createKakaoEvent(Member member, Meetup meetup) throws JsonProcessingException {
+    public void createKakaoEvent(Member member, Meetup meetup, String spotName) throws JsonProcessingException {
         String kakaoAccessToken = verifyAndRefreshKakaoToken(member.getEmail());
         ObjectMapper objectMapper = new ObjectMapper();
-        String kakaoEventString = objectMapper.writeValueAsString(KakaoEvent.from(meetup));
+        String kakaoEventString = objectMapper.writeValueAsString(KakaoEvent.from(meetup, spotName));
 
         DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory(KAKAO_CALENDAR_URL);
         factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE); //WebClient에 의한 Encoding 옵션 끄기

--- a/common/src/main/java/com/kuddy/common/security/service/OAuth2AuthenticationSuccessHandler.java
+++ b/common/src/main/java/com/kuddy/common/security/service/OAuth2AuthenticationSuccessHandler.java
@@ -72,8 +72,8 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             oauthRefreshToken = refreshToken != null
                     ? refreshToken.getTokenValue()
                     : redisService.getData("KakaoRefreshToken:" + email);
-            redisService.setData("KakaoAccessToken:" + email, oauthAccessToken, kakaoAccessTokenValidationMs);
-            redisService.setData("KakaoRefreshToken:" + email, oauthRefreshToken, kakaoRefreshTokenValidationMs);
+            redisService.setData("KakaoAccessToken:" + email, oauthAccessToken);
+            redisService.setData("KakaoRefreshToken:" + email, oauthRefreshToken);
         } else if (providerType.equals(ProviderType.GOOGLE)) {
             GoogleUserInfo googleUserInfo = new GoogleUserInfo(attributes);
             email = googleUserInfo.getEmail();
@@ -81,8 +81,8 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             oauthRefreshToken = refreshToken != null
                     ? refreshToken.getTokenValue()
                     : redisService.getData("GoogleRefreshToken:" + email);
-            redisService.setData("GoogleAccessToken:" + email, oauthAccessToken, googleAccessTokenValidationMs);
-            redisService.setData("GoogleRefreshToken:" + email, oauthRefreshToken, googleRefreshTokenValidationMs);
+            redisService.setData("GoogleAccessToken:" + email, oauthAccessToken);
+            redisService.setData("GoogleRefreshToken:" + email, oauthRefreshToken);
         } else {
             Map<String, Object> providerData = (Map<String, Object>) attributes.get(providerType.name().toLowerCase());
             if (providerData != null) {


### PR DESCRIPTION
Related to : #124

## 기능 명세
- [x] 캘린더 일정 생성/삭제 기능을 비동기 이벤트로 분리
- [x] 동행 상태 변경과 캘린더 일정 관리를 다른 트랙잭션에서 처리하도록 분리
## 결과 
- 웹소켓 메서드로 동행 상태(MeetupStatus)가 PAYED로 변경되는 경우 일정 생성 이벤트 발생
- 웹소켓 메서드로 동행 상태(MeetupStatus)가 KUDDY_CANCEL 또는 TRAVELER_CANCEL로 변경되는 경우 일정 삭제 이벤트 발생

## 함께 의논할 점

closes : #124 