### PR TITLE
[hotfix] 캘린더 일정 관련 기능을 API로 분리한다.

### DIFF
--- a/api-server/src/main/java/com/kuddy/apiserver/meetup/MeetUpPayedEventListener.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/meetup/MeetUpPayedEventListener.java
@@ -27,8 +27,8 @@ public class MeetUpPayedEventListener {
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, classes = MeetupService.MeetupPayedEvent.class)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleMeetupPayedEvent(MeetupService.MeetupPayedEvent event) throws IOException {
+        log.info("handleMeetupPayedEvent 발생");
         Long kuddyId = event.getKuddyId();
         Long travelerId = event.getTravelerId();
         log.info("kuddy id  :  " + String.valueOf(kuddyId));

--- a/api-server/src/main/java/com/kuddy/apiserver/notification/NotiController.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/notification/NotiController.java
@@ -78,18 +78,18 @@ public class NotiController {
 //        mailNotiService.sendReviewRequestEmail();
 //    }
 
-//    @PostMapping("/{meetupId}")
-//    public String acceptMeetup(@PathVariable Long meetupId){
+//    @PostMapping("/calendars/{chatId}")
+//    public String acceptMeetup(@PathVariable String chatId){
 //        String newMeetupStatus = "PAYED";
-//        meetupService.updateMeetupTest(meetupId, newMeetupStatus);
+//        meetupService.invokeCalendarEvent(chatId, newMeetupStatus);
 //
 //        return "일정 등록 완료";
 //    }
 //
-//    @DeleteMapping("/{meetupId}")
-//    public String deleteMeetup(@PathVariable Long meetupId){
+//    @DeleteMapping("/calendars/{chatId}")
+//    public String deleteMeetup(@PathVariable String chatId){
 //        String newMeetupStatus = "KUDDY_CANCEL";
-//        meetupService.updateMeetupTest(meetupId, newMeetupStatus);
+//        meetupService.invokeCalendarEvent(chatId, newMeetupStatus);
 //        return "일정 삭제 완료";
 //    }
 

--- a/api-server/src/main/java/com/kuddy/apiserver/notification/controller/NotificationController.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/notification/controller/NotificationController.java
@@ -3,6 +3,7 @@ package com.kuddy.apiserver.notification.controller;
 import com.kuddy.apiserver.notification.service.CommentNotiService;
 import com.kuddy.common.meetup.service.MeetupService;
 import com.kuddy.common.member.domain.Member;
+import com.kuddy.common.response.StatusEnum;
 import com.kuddy.common.response.StatusResponse;
 import com.kuddy.common.security.user.AuthUser;
 import lombok.RequiredArgsConstructor;
@@ -50,18 +51,26 @@ public class NotificationController {
     }
 
     @PostMapping("/calendars/{chatId}")
-    public String createCalendarEvent(@PathVariable String chatId){
+    public ResponseEntity<StatusResponse> createCalendarEvent(@PathVariable String chatId) {
         String newMeetupStatus = "PAYED";
         meetupService.invokeCalendarEvent(chatId, newMeetupStatus);
 
-        return "일정 등록 완료";
+        return ResponseEntity.ok(StatusResponse.builder()
+                .status(StatusEnum.OK.getStatusCode())
+                .message(StatusEnum.OK.getCode())
+                .data("일정 등록 완료")
+                .build());
     }
 
     @DeleteMapping("/calendars/{chatId}")
-    public String deleteCalendarEvent(@PathVariable String chatId){
+    public ResponseEntity<StatusResponse> deleteCalendarEvent(@PathVariable String chatId){
         String newMeetupStatus = "KUDDY_CANCEL";
         meetupService.invokeCalendarEvent(chatId, newMeetupStatus);
 
-        return "일정 삭제 완료";
+        return ResponseEntity.ok(StatusResponse.builder()
+                .status(StatusEnum.OK.getStatusCode())
+                .message(StatusEnum.OK.getCode())
+                .data("일정 삭제 완료")
+                .build());
     }
 }

--- a/api-server/src/main/java/com/kuddy/apiserver/notification/controller/NotificationController.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/notification/controller/NotificationController.java
@@ -1,6 +1,7 @@
 package com.kuddy.apiserver.notification.controller;
 
 import com.kuddy.apiserver.notification.service.CommentNotiService;
+import com.kuddy.common.meetup.service.MeetupService;
 import com.kuddy.common.member.domain.Member;
 import com.kuddy.common.response.StatusResponse;
 import com.kuddy.common.security.user.AuthUser;
@@ -16,6 +17,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequiredArgsConstructor
 public class NotificationController {
     private final CommentNotiService notificationService;
+    private final MeetupService meetupService;
 
     //알림 구독 (SSE)
     @GetMapping(value = "/subscribe", produces = "text/event-stream")
@@ -45,5 +47,21 @@ public class NotificationController {
     @GetMapping("/count")
     public ResponseEntity<StatusResponse> countUnreadNotifications(@AuthUser Member member){
         return notificationService.countUnreadCommentNotifications(member);
+    }
+
+    @PostMapping("/calendars/{chatId}")
+    public String createCalendarEvent(@PathVariable String chatId){
+        String newMeetupStatus = "PAYED";
+        meetupService.invokeCalendarEvent(chatId, newMeetupStatus);
+
+        return "일정 등록 완료";
+    }
+
+    @DeleteMapping("/calendars/{chatId}")
+    public String deleteCalendarEvent(@PathVariable String chatId){
+        String newMeetupStatus = "KUDDY_CANCEL";
+        meetupService.invokeCalendarEvent(chatId, newMeetupStatus);
+
+        return "일정 삭제 완료";
     }
 }

--- a/common/src/main/java/com/kuddy/common/meetup/service/CalendarEventFacade.java
+++ b/common/src/main/java/com/kuddy/common/meetup/service/CalendarEventFacade.java
@@ -12,6 +12,7 @@ import com.kuddy.common.notification.calendar.service.KakaoCalendarService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
@@ -26,6 +27,7 @@ public class CalendarEventFacade {
     private final GoogleCalendarService googleCalendarService;
     private final MemberRepository memberRepository;
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void createCalendarEvent(Long memberId, Meetup meetup, String spotName) throws IOException {
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
         log.info("member 소셜 :" + member.getProviderType());

--- a/common/src/main/java/com/kuddy/common/meetup/service/MeetupService.java
+++ b/common/src/main/java/com/kuddy/common/meetup/service/MeetupService.java
@@ -87,6 +87,7 @@ public class MeetupService implements ApplicationEventPublisherAware{
 			Long travelerId = meetup.getTraveler().getId();
 			String spotName = meetup.getSpot().getName();
 			MeetupStatus meetupStatus = MeetupStatus.fromString(message.getMeetStatus());
+			log.info("이벤트 발생");
 			switch (meetupStatus){
 				case PAYED:
 					eventPublisher.publishEvent(new MeetupPayedEvent(meetup,kuddyId, travelerId, spotName));
@@ -101,29 +102,26 @@ public class MeetupService implements ApplicationEventPublisherAware{
 		}
 	}
 
-	public void updateMeetupTest(Long meetupId, String newMeetupStatus){
-		Meetup meetup = meetupRepository.findById(meetupId).orElseThrow(MeetupNotFoundException::new);
-		boolean isMeetupStatusUpdated = !newMeetupStatus.equals(String.valueOf(meetup.getMeetupStatus()));
-		meetup.updateMeetupStatus("PAYED");
+	public void invokeCalendarEvent(String chatId, String newMeetupStatus){
+		Meetup meetup = meetupRepository.findByChatId(chatId).orElseThrow(MeetupNotFoundException::new);
 
-		if (isMeetupStatusUpdated) {
-			Long kuddyId = meetup.getKuddy().getId();
-			Long travelerId = meetup.getTraveler().getId();
-			String spotName = meetup.getSpot().getName();
-			MeetupStatus meetupStatus = MeetupStatus.fromString(newMeetupStatus);
-			switch (meetupStatus){
-				case PAYED:
-					eventPublisher.publishEvent(new MeetupPayedEvent(meetup, kuddyId, travelerId, spotName));
-					break;
-				case KUDDY_CANCEL:
-				case TRAVELER_CANCEL:
-					eventPublisher.publishEvent(new MeetupCanceledEvent(meetup));
-					break;
-				default:
-					break;
+		Long kuddyId = meetup.getKuddy().getId();
+		Long travelerId = meetup.getTraveler().getId();
+		String spotName = meetup.getSpot().getName();
+		MeetupStatus meetupStatus = MeetupStatus.fromString(newMeetupStatus);
+		switch (meetupStatus){
+			case PAYED:
+				eventPublisher.publishEvent(new MeetupPayedEvent(meetup, kuddyId, travelerId, spotName));
+				break;
+			case KUDDY_CANCEL:
+			case TRAVELER_CANCEL:
+				eventPublisher.publishEvent(new MeetupCanceledEvent(meetup));
+				break;
+			default:
+				break;
 			}
-		}
 	}
+
 	@Transactional(readOnly = true)
 	public Spot findByContentId(Long contentId){
 		return spotRepository.findByContentId(contentId);


### PR DESCRIPTION
## 기능 명세
- [x] 캘린더 일정 생성 기능 API
- [x] 캘린더 일정 삭제 기능 API

## 결과 
### [POST] /api/v1/notifications/calendars/{chatId}
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": "일정 등록 완료"
}
 ```
### [DELETE] /api/v1/notifications/calendars/{chatId}
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": "일정 삭제 완료"
}
```

## 함께 의논할 점
> - 없으면 생략 