### PR TITLE
[hotfix] 캘린더 일정 기능에서 발생하는 예외를 처리한다.

### DIFF
--- a/common/src/main/java/com/kuddy/common/notification/calendar/dto/KakaoEvent.java
+++ b/common/src/main/java/com/kuddy/common/notification/calendar/dto/KakaoEvent.java
@@ -48,8 +48,9 @@ public class KakaoEvent {
     public static KakaoEvent from(Meetup meetup, String spotName) {
         LocalDateTime dateTime = meetup.getAppointment();
         int minute = dateTime.getMinute();
+        int second = dateTime.getSecond();
         int remainder = minute % 5; // The minimum unit of start_at is 5 minutes
-        LocalDateTime adjustedDateTime = dateTime.minusMinutes(remainder);
+        LocalDateTime adjustedDateTime = dateTime.minusMinutes(remainder).minusSeconds(second);
         ZoneId koreaZone = ZoneId.of("Asia/Seoul");
         ZonedDateTime zonedDateTime = adjustedDateTime.atZone(koreaZone);
         ZonedDateTime endOfTheDay = zonedDateTime

--- a/common/src/main/java/com/kuddy/common/notification/calendar/service/GoogleCalendarService.java
+++ b/common/src/main/java/com/kuddy/common/notification/calendar/service/GoogleCalendarService.java
@@ -46,12 +46,16 @@ public class GoogleCalendarService {
     public String verifyAndRefreshGoogleToken(String email) throws JsonProcessingException {
         String googleAccessToken = redisService.getData("GoogleAccessToken:" + email);
         boolean isValidAccessToken = googleAuthService.validateGoogleAccessToken(googleAccessToken);
+
+        log.info("구글 액세스토큰 유효 여부 : " + isValidAccessToken);
+
+
+        // 구글 액세스 토큰이 유효하지 않을 경우, 리프레시 토큰을 이용하여 재발급
         if (!isValidAccessToken) {
-            String googleRefreshToken = redisService.getData("GoogleRefreshToken" + email);
+            String googleRefreshToken = redisService.getData("GoogleRefreshToken:" + email);
             Map<String, String> newTokens = googleAuthService.refreshGoogleTokens(googleRefreshToken);
 
-            redisService.setData("GoogleAccessToken:" + email, newTokens.get("access_token"), googleAccessTokenValidationMs);
-            redisService.setData("GoogleRefreshToken" + email, newTokens.get("refresh_token"), googleRefreshTokenValidationMs);
+            redisService.setData("GoogleAccessToken:" + email, newTokens.get("access_token"));
 
             return newTokens.get("access_token");
         } else {

--- a/common/src/main/java/com/kuddy/common/notification/calendar/service/KakaoAuthService.java
+++ b/common/src/main/java/com/kuddy/common/notification/calendar/service/KakaoAuthService.java
@@ -45,17 +45,13 @@ public class KakaoAuthService {
         ResponseEntity<String> response = wc.get()
                 .header("Authorization", "Bearer " + kakaoAccessToken)
                 .retrieve()
-                .onStatus(HttpStatus::is4xxClientError, clientResponse -> {
-                    // 4xx 클라이언트 오류 상태 코드 처리
-                    return Mono.error(new KakaoCalendarAPIException());
-                })
-                .onStatus(HttpStatus::is5xxServerError, clientResponse -> {
-                    // 5xx 서버 오류 상태 코드 처리
-                    return Mono.error(new KakaoCalendarAPIException());
-                })
+                // 4xx 클라이언트 오류 상태 코드 처리
+                .onStatus(HttpStatus::is4xxClientError, clientResponse -> Mono.error(new KakaoCalendarAPIException()))
+                // 5xx 서버 오류 상태 코드 처리
+                .onStatus(HttpStatus::is5xxServerError, clientResponse -> Mono.error(new KakaoCalendarAPIException()))
                 .toEntity(String.class).block();
 
-        return response.getStatusCode() == HttpStatus.OK;
+        return (response != null ? response.getStatusCode() : null) == HttpStatus.OK;
     }
 
     public Map<String, String> refreshKakaoTokens(String refreshToken) throws JsonProcessingException {

--- a/common/src/main/java/com/kuddy/common/notification/calendar/service/KakaoCalendarService.java
+++ b/common/src/main/java/com/kuddy/common/notification/calendar/service/KakaoCalendarService.java
@@ -47,8 +47,7 @@ public class KakaoCalendarService {
     // 카카오 access token 유효성 검사 및 재발급
     public String verifyAndRefreshKakaoToken(String email) throws JsonProcessingException {
         String kakaoAccessToken = redisService.getData("KakaoAccessToken:" + email);
-//        boolean isValidAccessToken = kakaoAuthService.validateKakaoAccessToken(kakaoAccessToken);
-        boolean isValidAccessToken = false;
+        boolean isValidAccessToken = kakaoAuthService.validateKakaoAccessToken(kakaoAccessToken);
         if (!isValidAccessToken) {
             String kakaoRefreshToken = redisService.getData("KakaoRefreshToken:" + email);
             Map<String, String> newTokens = kakaoAuthService.refreshKakaoTokens(kakaoRefreshToken);

--- a/common/src/main/java/com/kuddy/common/notification/calendar/service/KakaoCalendarService.java
+++ b/common/src/main/java/com/kuddy/common/notification/calendar/service/KakaoCalendarService.java
@@ -47,12 +47,16 @@ public class KakaoCalendarService {
     // 카카오 access token 유효성 검사 및 재발급
     public String verifyAndRefreshKakaoToken(String email) throws JsonProcessingException {
         String kakaoAccessToken = redisService.getData("KakaoAccessToken:" + email);
-        boolean isValidAccessToken = kakaoAuthService.validateKakaoAccessToken(kakaoAccessToken);
+//        boolean isValidAccessToken = kakaoAuthService.validateKakaoAccessToken(kakaoAccessToken);
+        boolean isValidAccessToken = false;
         if (!isValidAccessToken) {
             String kakaoRefreshToken = redisService.getData("KakaoRefreshToken:" + email);
             Map<String, String> newTokens = kakaoAuthService.refreshKakaoTokens(kakaoRefreshToken);
-            redisService.setData("KakaoAccessToken:" + email, newTokens.get("access_token"), kakaoAccessTokenValidationMs);
-            redisService.setData("KakaoRefreshToken:" + email, newTokens.get("refresh_token"), kakaoRefreshTokenValidationMs);
+            redisService.setData("KakaoAccessToken:" + email, newTokens.get("access_token"));
+            // refresh_token 값은 유효기간이 1개월 미만인 경우에만 갱신되어 담겨옴
+            if( newTokens.containsKey("refresh_token")){
+                redisService.setData("KakaoRefreshToken:" + email, newTokens.get("refresh_token"));
+            }
 
             return newTokens.get("access_token");
         } else {


### PR DESCRIPTION
## 기능 명세
- [x] accessToken 갱신시 재발급 기능 수정
## 결과 
- 외부 API(카카오 일정 생성/삭제, 구글 일정 생성/삭제) 호출시 발생할 수 있는 예외 처리
## 함께 의논할 점
> - 없으면 생략 