### PR TITLE
[refactor] 커디 top5 추출한 정보를 redis 캐싱한다. 

### DIFF
--- a/api-server/src/main/java/com/kuddy/apiserver/profile/controller/ProfileSearchController.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/profile/controller/ProfileSearchController.java
@@ -60,8 +60,7 @@ public class ProfileSearchController {
 
 	@GetMapping("kuddy/top5")
 	public ResponseEntity<StatusResponse> readTop5KuddyProfile() {
-		List<Profile> profileList = top5KuddyService.findTopKuddies();
-		Top5KuddyListResDto response = top5KuddyService.changePageToResponse(profileList);
+		Top5KuddyListResDto response = top5KuddyService.getTop5Kuddy();
 		return ResponseEntity.ok(StatusResponse.builder()
 				.status(StatusEnum.OK.getStatusCode())
 				.message(StatusEnum.OK.getCode())

--- a/api-server/src/main/java/com/kuddy/apiserver/profile/dto/response/Top5KuddyListResDto.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/profile/dto/response/Top5KuddyListResDto.java
@@ -9,15 +9,15 @@ import java.util.List;
 
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 @AllArgsConstructor
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Top5KuddyListResDto {
     private List<Top5KuddyResDto> top5KuddyList;
     private long size;
 
     @Getter
     @AllArgsConstructor
+    @NoArgsConstructor
     @Builder
     public static class Top5KuddyResDto{
         private Long memberId;
@@ -36,6 +36,13 @@ public class Top5KuddyListResDto {
                     .recentReview(recentReview)
                     .kuddyLevel(member.getProfile().getKuddyLevel())
                     .build();
+        }
+
+        public void setNickname(String newNickname){
+            this.nickname = newNickname;
+        }
+        public void setProfileImageUrl(String profileImageUrl){
+            this.profileImageUrl = profileImageUrl;
         }
     }
 

--- a/api-server/src/main/java/com/kuddy/apiserver/profile/service/ProfileService.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/profile/service/ProfileService.java
@@ -3,7 +3,6 @@ package com.kuddy.apiserver.profile.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
@@ -46,7 +45,8 @@ public class ProfileService {
 	private final MemberService memberService;
 	private final ProfileAreaService profileAreaService;
 	private final ProfileQueryService profileQueryService;
-	private final JPAQueryFactory queryFactory;
+	private final Top5KuddyService top5KuddyService;
+
 
 	public Long create(Member member, ProfileReqDto.Create reqDto){
 		if(existsProfileByMember(member)){
@@ -81,8 +81,10 @@ public class ProfileService {
 		setInterests(profile, reqDto.getInterests());
 		profileLanguageService.updateProfileLanguage(profile, reqDto.getAvailableLanguages());
 		profileAreaService.updateProfileDistricts(profile, reqDto.getDistricts());
+		top5KuddyService.updateTop5KuddiesCache(member);
 		return profile;
 	}
+
 
 	public void setInterests(Profile profile, InterestsDto reqDto){
 

--- a/common/src/main/java/com/kuddy/common/cache/config/RedisCacheConfig.java
+++ b/common/src/main/java/com/kuddy/common/cache/config/RedisCacheConfig.java
@@ -22,7 +22,7 @@ public class RedisCacheConfig {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())) // Value Serializer 변경
-                .entryTtl(Duration.ofHours(10L));
+                .entryTtl(Duration.ofDays(1L));
 
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(redisCacheConfiguration).build();
     }

--- a/common/src/main/java/com/kuddy/common/cache/config/RedisCacheConfig.java
+++ b/common/src/main/java/com/kuddy/common/cache/config/RedisCacheConfig.java
@@ -1,0 +1,29 @@
+package com.kuddy.common.cache.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    @Bean
+    public CacheManager contentCacheManager(RedisConnectionFactory cf) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())) // Value Serializer 변경
+                .entryTtl(Duration.ofHours(10L));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(redisCacheConfiguration).build();
+    }
+}


### PR DESCRIPTION
## 기능 명세
- [x] 커디 top5 추출한 정보를 redis 캐싱한다. 
- [x] 하루마다 업데이트를 하여 다시 추출한 뒤 캐싱한다.
- [x] member의 정보(닉네임, 프로필사진) 업데이트 시점 전에 변경될 경우 해당 member만 캐싱했던 정보를 변경한다. 
        하루 기준으로 순위가 없데이트되는 것이기 때문에 최신 리뷰는 변경되면 되므로 전체 캐싱 무효화가 아닌 해당 member를 찾아서 변경된 
        부분만 변경되도록 한다.

## 결과 
api/v1/profiles/kuddy/top5
기존 응답과 동일

## 함께 의논할 점
#135 이 내용 참고해주시고 리뷰 부탁드립니다!