### PR TITLE
[hotfix] 닉네임 변경 시 MySQL과 mongoDB 동기화

### DIFF
--- a/api-server/src/main/java/com/kuddy/apiserver/profile/service/ProfileService.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/profile/service/ProfileService.java
@@ -3,6 +3,7 @@ package com.kuddy.apiserver.profile.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.kuddy.common.chat.service.ChattingUpdateService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
@@ -45,6 +46,7 @@ public class ProfileService {
 	private final MemberService memberService;
 	private final ProfileAreaService profileAreaService;
 	private final ProfileQueryService profileQueryService;
+	private final ChattingUpdateService chattingUpdateService;
 	private final Top5KuddyService top5KuddyService;
 
 
@@ -68,7 +70,9 @@ public class ProfileService {
 		Profile profile = findByMember(member);
 		Member findMember = memberService.findById(member.getId());
 
-		findMember.updateNickname(reqDto.getNickname());
+		if(findMember.updateNickname(reqDto.getNickname())){
+			chattingUpdateService.updateSenderNameInChatting(findMember);
+		}
 		findMember.updateProfileImage(reqDto.getProfileImageUrl());
 		profile.changeJob(reqDto.getJob());
 		profile.updateIntroduce(reqDto.getIntroduce());

--- a/common/src/main/java/com/kuddy/common/chat/domain/mongo/Chatting.java
+++ b/common/src/main/java/com/kuddy/common/chat/domain/mongo/Chatting.java
@@ -39,6 +39,11 @@ public class Chatting { //MongoDB에서 메시지 저장에 사용할 도메인 
 	private String price;
 	//동행일 경우 범위끝
 
+	public void updateSenderName(String newNickname){
+		if(!this.senderName.equals(newNickname)){
+			this.senderName = newNickname;
+		}
+	}
 
 
 }

--- a/common/src/main/java/com/kuddy/common/chat/repository/MongoChatRepository.java
+++ b/common/src/main/java/com/kuddy/common/chat/repository/MongoChatRepository.java
@@ -11,8 +11,11 @@ import com.kuddy.common.chat.domain.mongo.Chatting;
 
 public interface MongoChatRepository extends MongoRepository<Chatting, String> {
 
+
 	List<Chatting> findByRoomId(Long roomId);
 	Optional<Chatting> findById(String id);
 
 	Page<Chatting> findByRoomIdOrderBySendTimeDesc(Long roomId, Pageable pageable);
+
+	List<Chatting> findBySenderId(Long memberId);
 }

--- a/common/src/main/java/com/kuddy/common/chat/service/ChattingUpdateService.java
+++ b/common/src/main/java/com/kuddy/common/chat/service/ChattingUpdateService.java
@@ -1,0 +1,25 @@
+package com.kuddy.common.chat.service;
+
+import com.kuddy.common.chat.domain.mongo.Chatting;
+import com.kuddy.common.chat.repository.MongoChatRepository;
+import com.kuddy.common.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChattingUpdateService {
+    private final MongoChatRepository mongoChatRepository;
+    public void updateSenderNameInChatting(Member member) {
+        List<Chatting> chats = mongoChatRepository.findBySenderId(member.getId());
+
+        for (Chatting chat : chats) {
+            chat.updateSenderName(member.getNickname());
+            mongoChatRepository.save(chat);
+        }
+    }
+}

--- a/common/src/main/java/com/kuddy/common/member/domain/Member.java
+++ b/common/src/main/java/com/kuddy/common/member/domain/Member.java
@@ -84,10 +84,12 @@ public class Member extends BaseTimeEntity {
 			this.email = email;
 		}
 	}
-	public void updateNickname(String nickname) {
-		if (validateNickName(nickname)) {
+	public boolean updateNickname(String nickname) {
+		if (validateNickName(nickname) && !this.nickname.equals(nickname)) {
 			this.nickname = nickname;
+			return true;
 		}
+		return false;
 	}
 	public void updateRole(RoleType roleType) {
 		if (roleType != null && !this.roleType.equals(roleType)) {


### PR DESCRIPTION
## 기능 명세
- [x] 닉네임 변경 시 채팅 db도 변경

## 결과 
기존 프로필 수정 응답값과 동일(변경 없음)

## 함께 의논할 점
일단 임시 방편으로 공통 모듈에 서비스 로직으로 구현했습니다. 하지만 공통 모듈이 커진다는 단점이 있어 추후 이벤트기반처리를 통해 api 모듈 닉네임 변경 이벤트 발생시 chat 모듈에서 메시지 큐(카프카)에서 수신받아 채팅 db에도 변경될 수 있도록 변경할 예정입니다!

#145 