### PR TITLE
[hotfix] 카카오 톡캘린더 일정 생성 기능을 수정한다

### DIFF
--- a/api-server/src/main/java/com/kuddy/apiserver/auth/controller/AuthController.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/auth/controller/AuthController.java
@@ -5,6 +5,9 @@ import static org.springframework.http.HttpHeaders.*;
 import javax.servlet.http.Cookie;
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.kuddy.common.notification.calendar.service.KakaoAuthService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -21,12 +24,15 @@ import com.kuddy.common.response.StatusResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Map;
+
 @Slf4j
 @RestController
 @RequestMapping("api/v1/token")
 @RequiredArgsConstructor
 public class AuthController {
 	private final AuthService authService;
+	private final KakaoAuthService kakaoAuthService;
 
 	private static final String LOGOUT_SUCCESS = "성공적으로 로그아웃 되었습니다.";
 
@@ -57,6 +63,15 @@ public class AuthController {
 			.message(StatusEnum.OK.getCode())
 			.data(resDto)
 			.build());
+	}
+
+	@PostMapping("/calendar")
+	public ResponseEntity<StatusResponse> createToken(@RequestBody Map<String, String> payload) throws JsonProcessingException {
+		kakaoAuthService.createToken(payload);
+		return ResponseEntity.ok(StatusResponse.builder()
+				.status(StatusEnum.OK.getStatusCode())
+				.message(StatusEnum.OK.getCode())
+				.build());
 	}
 
 }

--- a/api-server/src/main/java/com/kuddy/apiserver/auth/service/AuthService.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/auth/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.kuddy.apiserver.auth.service;
 
+import com.kuddy.common.security.user.KakaoUserInfo;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -15,9 +17,12 @@ import com.kuddy.common.security.exception.InvalidRefreshTokenException;
 import com.kuddy.common.security.exception.InvalidTokenException;
 import com.kuddy.common.security.exception.InvalidTokenTypeException;
 import com.kuddy.common.security.exception.NotMatchStoredResfreshTokenException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -91,6 +96,4 @@ public class AuthService {
 		redisService.setData("BlackList:" + accessToken, "signOut", remainingTime);
 		redisService.deleteData("RefreshToken:" + authentication.getName());
 	}
-
-
 }

--- a/api-server/src/main/java/com/kuddy/apiserver/meetup/MeetUpPayedEventListener.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/meetup/MeetUpPayedEventListener.java
@@ -25,24 +25,24 @@ public class MeetUpPayedEventListener {
     private final CalendarEventFacade calendarEventFacade;
     private final CalendarRepository calendarRepository;
 
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, classes = MeetupService.MeetupPayedEvent.class)
-    public void handleMeetupPayedEvent(MeetupService.MeetupPayedEvent event) throws IOException {
-        log.info("handleMeetupPayedEvent 발생");
-        Long kuddyId = event.getKuddyId();
-        Long travelerId = event.getTravelerId();
-        log.info("kuddy id  :  " + String.valueOf(kuddyId));
-        log.info("traveler id  :  " + String.valueOf(travelerId));
+//    @Async
+//    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, classes = MeetupService.MeetupPayedEvent.class)
+//    public void handleMeetupPayedEvent(MeetupService.MeetupPayedEvent event) throws IOException {
+//        log.info("handleMeetupPayedEvent 발생");
+//        Long kuddyId = event.getKuddyId();
+//        Long travelerId = event.getTravelerId();
+//        log.info("kuddy id  :  " + String.valueOf(kuddyId));
+//        log.info("traveler id  :  " + String.valueOf(travelerId));
+//
+//        calendarEventFacade.createCalendarEvent(kuddyId, event.getMeetup(), event.getSpotName());
+//        calendarEventFacade.createCalendarEvent(travelerId, event.getMeetup(), event.getSpotName());
+//    }
 
-        calendarEventFacade.createCalendarEvent(kuddyId, event.getMeetup(), event.getSpotName());
-        calendarEventFacade.createCalendarEvent(travelerId, event.getMeetup(), event.getSpotName());
-    }
-
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, classes = MeetupService.MeetupCanceledEvent.class)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void handleMeetupCanceledEvent(MeetupService.MeetupCanceledEvent event) throws JsonProcessingException {
-        List<Calendar> eventList = calendarRepository.findAllByMeetup_Id(event.getMeetup().getId());
-        calendarEventFacade.deleteEvents(eventList);
-    }
+//    @Async
+//    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, classes = MeetupService.MeetupCanceledEvent.class)
+//    @Transactional(propagation = Propagation.REQUIRES_NEW)
+//    public void handleMeetupCanceledEvent(MeetupService.MeetupCanceledEvent event) throws JsonProcessingException {
+//        List<Calendar> eventList = calendarRepository.findAllByMeetup_Id(event.getMeetup().getId());
+//        calendarEventFacade.deleteEvents(eventList);
+//    }
 }

--- a/common/src/main/java/com/kuddy/common/exception/type/ExceptionType.java
+++ b/common/src/main/java/com/kuddy/common/exception/type/ExceptionType.java
@@ -19,6 +19,7 @@ import com.kuddy.common.exception.custom.ApplicationException;
 import com.kuddy.common.meetup.exception.NotAdminException;
 import com.kuddy.common.notification.exception.GoogleCalendarAPIException;
 import com.kuddy.common.notification.exception.KakaoCalendarAPIException;
+import com.kuddy.common.notification.exception.KakaoCalendarAPIPermissionException;
 import com.kuddy.common.notification.exception.NotificationNotFoundException;
 import com.kuddy.common.profile.exception.DuplicateProfileException;
 import com.kuddy.common.profile.exception.WithdrawMemberProfileException;
@@ -143,7 +144,8 @@ public enum ExceptionType {
 	//알림 관련 - C13***
 	GOOGLE_CALENDAR_API_EXCEPTION("C13000", "Google Calendar API를 불러올 수 없습니다.", GoogleCalendarAPIException.class),
 	KAKAO_CALENDAR_API_EXCEPTION("C13001", "Kakao 톡캘린더 API를 불러올 수 없습니다.", KakaoCalendarAPIException.class),
-	NOTIFICATION_NOT_FOUND_EXCEPTION("C13002", "해당 알림을 찾을 수 없습니다.", NotificationNotFoundException.class);
+	NOTIFICATION_NOT_FOUND_EXCEPTION("C13002", "해당 알림을 찾을 수 없습니다.", NotificationNotFoundException.class),
+	KAKAO_CALENDAR_API_PERMISSION_EXCEPTION("C13003", "톡캘린더 권한 동의가 필요합니다.", KakaoCalendarAPIPermissionException.class);
 
 	private final String errorCode;
 	private final String message;

--- a/common/src/main/java/com/kuddy/common/meetup/service/CalendarEventFacade.java
+++ b/common/src/main/java/com/kuddy/common/meetup/service/CalendarEventFacade.java
@@ -27,25 +27,25 @@ public class CalendarEventFacade {
     private final GoogleCalendarService googleCalendarService;
     private final MemberRepository memberRepository;
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void createCalendarEvent(Long memberId, Meetup meetup, String spotName) throws IOException {
-        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
-        log.info("member 소셜 :" + member.getProviderType());
-        if (member.getProviderType().equals(ProviderType.KAKAO)) {
-            kakaoCalendarService.createKakaoEvent(member, meetup, spotName);
-        } else {
-            googleCalendarService.createGoogleEvent(member, meetup, spotName);
-        }
-    }
-
-    public void deleteEvents(List<Calendar> eventList) throws JsonProcessingException {
-        for(Calendar event : eventList){
-            if (event.getMember().getProviderType().equals(ProviderType.KAKAO)) {
-                kakaoCalendarService.deleteCalendarEvent(event);
-            } else {
-                googleCalendarService.deleteCalendarEvent(event);
-            }
-        }
-
-    }
+//    @Transactional(propagation = Propagation.REQUIRES_NEW)
+//    public void createCalendarEvent(Long memberId, Meetup meetup, String spotName) throws IOException {
+//        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+//        log.info("member 소셜 :" + member.getProviderType());
+//        if (member.getProviderType().equals(ProviderType.KAKAO)) {
+//            kakaoCalendarService.createKakaoEvent(member, meetup, spotName);
+//        } else {
+//            googleCalendarService.createGoogleEvent(member, meetup, spotName);
+//        }
+//    }
+//
+//    public void deleteEvents(List<Calendar> eventList) throws JsonProcessingException {
+//        for(Calendar event : eventList){
+//            if (event.getMember().getProviderType().equals(ProviderType.KAKAO)) {
+//                kakaoCalendarService.deleteCalendarEvent(event);
+//            } else {
+//                googleCalendarService.deleteCalendarEvent(event);
+//            }
+//        }
+//
+//    }
 }

--- a/common/src/main/java/com/kuddy/common/meetup/service/MeetupService.java
+++ b/common/src/main/java/com/kuddy/common/meetup/service/MeetupService.java
@@ -102,24 +102,11 @@ public class MeetupService implements ApplicationEventPublisherAware{
 		}
 	}
 
-	public void invokeCalendarEvent(String chatId, String newMeetupStatus){
-		Meetup meetup = meetupRepository.findByChatId(chatId).orElseThrow(MeetupNotFoundException::new);
+	public void invokeCalendarEvent(Long meetupId, Member member) throws JsonProcessingException {
+		Meetup meetup = meetupRepository.findById(meetupId).orElseThrow(MeetupNotFoundException::new);
+		Spot spot = meetup.getSpot();
+		kakaoCalendarService.createKakaoEvent(member, meetup, spot);
 
-		Long kuddyId = meetup.getKuddy().getId();
-		Long travelerId = meetup.getTraveler().getId();
-		String spotName = meetup.getSpot().getName();
-		MeetupStatus meetupStatus = MeetupStatus.fromString(newMeetupStatus);
-		switch (meetupStatus){
-			case PAYED:
-				eventPublisher.publishEvent(new MeetupPayedEvent(meetup, kuddyId, travelerId, spotName));
-				break;
-			case KUDDY_CANCEL:
-			case TRAVELER_CANCEL:
-				eventPublisher.publishEvent(new MeetupCanceledEvent(meetup));
-				break;
-			default:
-				break;
-			}
 	}
 
 	@Transactional(readOnly = true)

--- a/common/src/main/java/com/kuddy/common/notification/calendar/dto/KakaoEvent.java
+++ b/common/src/main/java/com/kuddy/common/notification/calendar/dto/KakaoEvent.java
@@ -24,6 +24,8 @@ public class KakaoEvent {
     @Getter
     public static class Location {
         private String name;
+        private String latitude;
+        private String longitude;
     }
 
     @Getter
@@ -45,7 +47,7 @@ public class KakaoEvent {
         this.reminders = reminders;
     }
 
-    public static KakaoEvent from(Meetup meetup, String spotName) {
+    public static KakaoEvent from(Meetup meetup, Spot spot) {
         LocalDateTime dateTime = meetup.getAppointment();
         int minute = dateTime.getMinute();
         int second = dateTime.getSecond();
@@ -74,8 +76,11 @@ public class KakaoEvent {
                 .lunar(false)
                 .build();
 
+
         Location location = Location.builder()
-                .name(spotName)
+                .name(spot.getName())
+                .latitude(spot.getMapX())
+                .longitude(spot.getMapY())
                 .build();
 
         int[] reminders = {1440};  // 동행 하루 전 알림

--- a/common/src/main/java/com/kuddy/common/notification/calendar/dto/KakaoToken.java
+++ b/common/src/main/java/com/kuddy/common/notification/calendar/dto/KakaoToken.java
@@ -1,0 +1,19 @@
+package com.kuddy.common.notification.calendar.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class KakaoToken {
+
+    private String token_type;
+    private String access_token;
+    private Integer expires_in;
+    private String refresh_token;
+    private Integer refresh_token_expires_in;
+    private String scope;
+    private String id_token;
+
+}
+

--- a/common/src/main/java/com/kuddy/common/notification/calendar/dto/KakaoUser.java
+++ b/common/src/main/java/com/kuddy/common/notification/calendar/dto/KakaoUser.java
@@ -1,0 +1,31 @@
+package com.kuddy.common.notification.calendar.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+public class KakaoUser {
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Data
+    public static class KakaoAccount {
+
+        private Profile profile;
+        private String email;
+        private boolean profile_nickname_needs_agreement;
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        @Data
+        public static class Profile {
+            private String nickname;
+
+            @JsonProperty("profile_image_url")
+            private String profileImageURL;
+        }
+    }
+}

--- a/common/src/main/java/com/kuddy/common/notification/calendar/service/GoogleAuthService.java
+++ b/common/src/main/java/com/kuddy/common/notification/calendar/service/GoogleAuthService.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kuddy.common.notification.calendar.dto.NewGoogleAccessTokenReqDto;
 import com.kuddy.common.notification.exception.GoogleCalendarAPIException;
-import com.kuddy.common.notification.exception.KakaoCalendarAPIException;
 import com.kuddy.common.redis.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/common/src/main/java/com/kuddy/common/notification/calendar/service/KakaoAuthService.java
+++ b/common/src/main/java/com/kuddy/common/notification/calendar/service/KakaoAuthService.java
@@ -3,8 +3,16 @@ package com.kuddy.common.notification.calendar.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kuddy.common.jwt.JwtProvider;
+import com.kuddy.common.member.domain.Member;
+import com.kuddy.common.member.exception.MemberNotFoundException;
+import com.kuddy.common.member.repository.MemberRepository;
+import com.kuddy.common.notification.calendar.dto.KakaoUser;
 import com.kuddy.common.notification.exception.KakaoCalendarAPIException;
 import com.kuddy.common.redis.RedisService;
+import com.kuddy.common.security.exception.InvalidJsonFormatException;
+import com.kuddy.common.util.HttpUtils;
+import com.kuddy.common.util.ObjectMapperUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,6 +24,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import org.springframework.http.*;
 
 import java.util.Map;
 
@@ -24,6 +33,8 @@ import java.util.Map;
 @Slf4j
 public class KakaoAuthService {
     private final RedisService redisService;
+    private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
     private static final String TOKEN_CHECK_URI = "https://kapi.kakao.com/v1/user/access_token_info";
     private static final String TOKEN_REFRESH_URI = "https://kauth.kakao.com/oauth/token";
 
@@ -42,6 +53,9 @@ public class KakaoAuthService {
     @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
     private String USER_INFO_URI;
 
+    @Value("${calendar.kakao.redirect-uri}")
+    private String CALENDAR_REDIRECT_URI;
+
     public boolean validateKakaoAccessToken(String kakaoAccessToken) {
         WebClient wc = WebClient.create(TOKEN_CHECK_URI);
         try{
@@ -49,9 +63,15 @@ public class KakaoAuthService {
                     .header("Authorization", "Bearer " + kakaoAccessToken)
                     .retrieve()
                     // 4xx 클라이언트 오류 상태 코드 처리
-                    .onStatus(HttpStatus::is4xxClientError, clientResponse -> Mono.error(new KakaoCalendarAPIException()))
+                    .onStatus(HttpStatus::is4xxClientError, clientResponse -> {
+                        int statusCode = clientResponse.rawStatusCode();
+                        return Mono.error(new KakaoCalendarAPIException());
+                    })
                     // 5xx 서버 오류 상태 코드 처리
-                    .onStatus(HttpStatus::is5xxServerError, clientResponse -> Mono.error(new KakaoCalendarAPIException()))
+                    .onStatus(HttpStatus::is5xxServerError, clientResponse -> {
+                        int statusCode = clientResponse.rawStatusCode();
+                        return Mono.error(new KakaoCalendarAPIException());
+                    })
                     .toEntity(String.class).block();
 
             return (response != null ? response.getStatusCode() : null) == HttpStatus.OK;
@@ -85,4 +105,45 @@ public class KakaoAuthService {
         }
         return null;
     }
+
+    public void createToken(Map<String, String> payload) {
+        String code = payload.get("code");
+        Map<String, String> tokens = getTokensFromKakao(code);
+
+        String kakaoAccessToken = tokens.get("access_token");
+
+        Member authMember = getKakaoUserInfo(kakaoAccessToken);
+        redisService.setData("KakaoAccessToken:" + authMember.getEmail(),kakaoAccessToken);
+    }
+
+    public Map<String, String> getTokensFromKakao(String code) {
+
+        try {
+            final String requestUrl = HttpUtils.createRequestUrlToGetToken("https://kauth.kakao.com/oauth/token", "authorization_code", CLIENTID, CALENDAR_REDIRECT_URI, code);
+            ResponseEntity<String> responseEntity = HttpUtils.sendRequest(requestUrl, HttpMethod.POST, HttpEntity.EMPTY, String.class);
+
+            return ObjectMapperUtil.readValue(responseEntity.getBody(), new TypeReference<Map<String, String>>() {});
+        }
+
+        catch (JsonProcessingException e) {
+
+            log.error("Error occurred while processing JSON: ", e);
+            throw new InvalidJsonFormatException();
+        }
+    }
+
+    public Member getKakaoUserInfo(String kakaoAccessToken){
+        try{
+            ResponseEntity<String> responseEntity =
+                    HttpUtils.sendRequest("https://kapi.kakao.com/v2/user/me", HttpMethod.GET, HttpUtils.createEntity(kakaoAccessToken), String.class);
+            KakaoUser kakaoUser = ObjectMapperUtil.readValue(responseEntity.getBody(), KakaoUser.class);
+            Member member = memberRepository.findByEmail(kakaoUser.getKakaoAccount().getEmail()).orElseThrow(()-> new MemberNotFoundException());
+            return member;
+
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
 }

--- a/common/src/main/java/com/kuddy/common/notification/exception/KakaoCalendarAPIException.java
+++ b/common/src/main/java/com/kuddy/common/notification/exception/KakaoCalendarAPIException.java
@@ -1,6 +1,9 @@
 package com.kuddy.common.notification.exception;
 
+import com.kuddy.common.exception.custom.BadRequestException;
+import com.kuddy.common.exception.custom.ForbiddenException;
 import com.kuddy.common.exception.custom.ServerErrorException;
 
-public class KakaoCalendarAPIException extends ServerErrorException {
+public class KakaoCalendarAPIException extends BadRequestException {
+
 }

--- a/common/src/main/java/com/kuddy/common/notification/exception/KakaoCalendarAPIPermissionException.java
+++ b/common/src/main/java/com/kuddy/common/notification/exception/KakaoCalendarAPIPermissionException.java
@@ -1,0 +1,7 @@
+package com.kuddy.common.notification.exception;
+
+import com.kuddy.common.exception.custom.ApplicationException;
+import com.kuddy.common.exception.custom.ForbiddenException;
+
+public class KakaoCalendarAPIPermissionException extends ForbiddenException {
+}

--- a/common/src/main/java/com/kuddy/common/security/exception/InvalidJsonFormatException.java
+++ b/common/src/main/java/com/kuddy/common/security/exception/InvalidJsonFormatException.java
@@ -1,0 +1,7 @@
+package com.kuddy.common.security.exception;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class InvalidJsonFormatException extends RuntimeException{
+}

--- a/common/src/main/java/com/kuddy/common/security/service/CustomOAuth2UserService.java
+++ b/common/src/main/java/com/kuddy/common/security/service/CustomOAuth2UserService.java
@@ -33,7 +33,6 @@ import lombok.extern.slf4j.Slf4j;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 	private final MemberRepository memberRepository;
 
-
 	@Override
 	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 		OAuth2User oAuth2User = super.loadUser(userRequest);

--- a/common/src/main/java/com/kuddy/common/security/service/OAuth2AuthenticationSuccessHandler.java
+++ b/common/src/main/java/com/kuddy/common/security/service/OAuth2AuthenticationSuccessHandler.java
@@ -114,7 +114,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     private String makeRedirectUrl(String email, String redirectUrl) {
 
         if (redirectUrl.equals(getDefaultTargetUrl())) {
-            redirectUrl = "http://localhost:3000";
+            redirectUrl = "http://localhost:8080/login/oauth2/code/kakao";
         }
         log.info(redirectUrl);
 

--- a/common/src/main/java/com/kuddy/common/util/HttpUtils.java
+++ b/common/src/main/java/com/kuddy/common/util/HttpUtils.java
@@ -1,0 +1,60 @@
+package com.kuddy.common.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+
+@Slf4j
+public class HttpUtils {
+    public static <T> ResponseEntity<T> sendRequest(String url, HttpMethod method, HttpEntity<?> entity, Class<T> responseType) {
+        RestTemplate restTemplate = new RestTemplate();
+        try {
+            return restTemplate.exchange(url, method, entity, responseType);
+        } catch (Exception e) {
+            log.error("Error occurred: ", e);
+            throw new RuntimeException("Failed to send HTTP request.");
+        }
+    }
+
+    public static HttpEntity<?> createEntity(String accessToken) {
+
+        return new HttpEntity<>(createHeaderWithAccessToken(accessToken));
+    }
+
+    public static HttpHeaders createHeaderWithAccessToken(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        return headers;
+    }
+
+    public static HttpHeaders createHeaderWithRefreshToken(String accessToken, String refreshToken){
+
+        HttpHeaders headers = createHeaderWithAccessToken(accessToken);
+        headers.add("RefreshToken", refreshToken);
+        return headers;
+    }
+
+    public static String createRequestUrlToGetToken(String url, String grantType, String clientId, String redirectUri, String code) {
+        return UriComponentsBuilder.fromHttpUrl(url)
+                .queryParam("grant_type", grantType)
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("code", code)
+                .toUriString();
+    }
+
+    public static String createRequestUrlToGetTokenWithRefreshToken(String url, String grantType, String clientId, String refreshToken, String clientSecret) {
+        return UriComponentsBuilder.fromHttpUrl(url)
+                .queryParam("grant_type", grantType)
+                .queryParam("client_id", clientId)
+                .queryParam("refresh_token", refreshToken)
+                .queryParam("client_secret", clientSecret)
+                .toUriString();
+    }
+
+}

--- a/common/src/main/java/com/kuddy/common/util/ObjectMapperUtil.java
+++ b/common/src/main/java/com/kuddy/common/util/ObjectMapperUtil.java
@@ -1,0 +1,24 @@
+package com.kuddy.common.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+
+public class ObjectMapperUtil {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static <T> T readValue(String json, Class<T> valueType) throws JsonProcessingException {
+        return objectMapper.readValue(json, valueType);
+    }
+
+    public static <T> T readValue(String json, TypeReference<T> valueTypeRef) throws JsonProcessingException {
+        return objectMapper.readValue(json, valueTypeRef);
+    }
+
+    public static String writeValueAsString(Object value) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(value);
+    }
+
+}


### PR DESCRIPTION
## 기능 명세
- [x] 톡캘린더 생성 과정에서 톡캘린더에 대한 추가 권한 동의를 완료하지 않은 유저는 인가코드를 발급해 새로 accees token을 발급하도록 수정.

## 결과 
### [POST] api/v1/token/calendar
인가코드를 받아 카카오 access token을 새로 발급한다.
```json
{
    "status": 200,
    "message": "SUCCESS"
}
```

### [POST] /api/v1/notifications/calendars/{meetupId}

200 OK
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": "일정 등록 완료"
}
```

403 권한 동의 미완료
```json
{
    "status": "FORBIDDEN",
    "errorCode": "C13003",
    "message": "톡캘린더 권한 동의가 필요합니다."
}
```

## 함께 의논할 점
> - 없으면 생략 

closes : #147 