### PR TITLE
[hotfix] 커뮤니티 관련 이슈를 해결한다2

### DIFF
--- a/api-server/src/main/java/com/kuddy/apiserver/comment/dto/response/MyCommentResDto.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/comment/dto/response/MyCommentResDto.java
@@ -2,6 +2,7 @@ package com.kuddy.apiserver.comment.dto.response;
 
 import com.kuddy.common.comment.domain.Comment;
 import com.kuddy.common.community.domain.Post;
+import com.kuddy.common.community.domain.PostType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,12 +15,14 @@ public class MyCommentResDto {
     private String postType;
     private String postTitle;
     private LocalDateTime createdDate;
+    private Boolean isJoinus;
 
     public static MyCommentResDto of(Comment comment) {
         Post post = comment.getPost();
         return MyCommentResDto.builder()
                 .id(comment.getId())
-                .postType(post.getPostType().getType())
+                .postType(post.getPostType().equals(PostType.ITINERARY)?"itinerary":"talkingBoard")
+                .isJoinus(post.getPostType().equals(PostType.JOIN_US))
                 .postTitle(post.getTitle())
                 .createdDate(comment.getCreatedDate())
                 .build();


### PR DESCRIPTION
 ## 기능 명세
- [x] 내 댓글 조회 기능 api 수정 :  "itinerary" 또는 "talkingBoard"로만 리턴하도록 변경 &  isJoinus 필드(Boolean) 추가

## 결과 
### [GET] /api/v1/comments/my
내 댓글 조회
 ```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": [
        {
            "id": 44,
            "postType": "talkingBoard",
            "postTitle": "test",
            "createdDate": "2023-10-10T06:03:10.705247",
            "isJoinus": true
        },
        {
            "id": 43,
            "postType": "talkingBoard",
            "postTitle": "Please choose a good restaurant in Sinchon",
            "createdDate": "2023-10-10T06:02:59.811488",
            "isJoinus": false
        },
        {
            "id": 42,
            "postType": "itinerary",
            "postTitle": "Anyone want to go to Gyeongbokgung with me tomorrow?",
            "createdDate": "2023-10-10T06:02:32.662572",
            "isJoinus": false
        }
    ]
}

 ```

## 함께 의논할 점
