### PR TITLE
[feature] 검색 시 정렬 조건을 추가한다. 

### DIFF
--- a/api-server/src/main/java/com/kuddy/apiserver/meetup/dto/MeetupListResDto.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/meetup/dto/MeetupListResDto.java
@@ -49,7 +49,7 @@ public class MeetupListResDto {
 
 			// Null-check for spot
 			if (meetup.getSpot() != null) {
-				this.spotId = meetup.getSpot().getId();
+				this.spotId = meetup.getSpot().getContentId();
 				this.spotName = meetup.getSpot().getName();
 			} else {
 				this.spotId = null;

--- a/api-server/src/main/java/com/kuddy/apiserver/profile/service/ProfileQueryService.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/profile/service/ProfileQueryService.java
@@ -7,14 +7,16 @@ import static com.kuddy.common.profile.domain.QProfile.profile;
 import static com.kuddy.common.profile.domain.QProfileArea.*;
 
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.kuddy.common.member.domain.RoleType;
 
 import com.kuddy.common.profile.domain.*;
 
-
 import com.querydsl.jpa.impl.JPAQuery;
+
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -39,19 +41,14 @@ import lombok.RequiredArgsConstructor;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class ProfileQueryService {
 	private final JPAQueryFactory queryFactory;
 
 
 
 	public Page<Profile> findAllExcludeNotKuddyOrderedByKuddyLevel(Pageable pageable) {
-		OrderSpecifier<Integer> orderSpecifier = new CaseBuilder()
-				.when(profile.kuddyLevel.stringValue().eq("SOULMATE")).then(1)
-				.when(profile.kuddyLevel.stringValue().eq("HARMONY")).then(2)
-				.when(profile.kuddyLevel.stringValue().eq("FRIEND")).then(3)
-				.when(profile.kuddyLevel.stringValue().eq("EXPLORER")).then(4)
-				.otherwise(9999)
-				.asc();
+		OrderSpecifier<Integer> orderSpecifier = kuddyLevelOrderSpecifier();
 
 		List<Profile> profiles = queryFactory
 				.selectFrom(profile)
@@ -125,43 +122,70 @@ public class ProfileQueryService {
 
 	}
 
-
 	public Page<Profile> findProfilesBySearchCriteria(int page, int size, ProfileSearchReqDto searchCriteria) {
 		Pageable pageable = PageRequest.of(page, size);
 		BooleanBuilder builder = new BooleanBuilder();
+		List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+		addDefaultOrder(orderSpecifiers);
 
-		// GenderType 검색 조건
+		// 각 검색 조건 적용
+		applyGenderTypeFilter(searchCriteria, builder);
+		applyAreaFilter(searchCriteria, builder);
+		applyInterestFilter(searchCriteria, builder);
+		applyNicknameFilter(searchCriteria, builder, orderSpecifiers);
+		applyRoleTypeFilter(searchCriteria, builder);
+
+		// Query 실행
+		List<Profile> profiles = executeQuery(builder, orderSpecifiers,pageable);
+		JPAQuery<Long> countQuery = createCountQuery(builder);
+
+		return PageableExecutionUtils.getPage(profiles, pageable, countQuery::fetchOne);
+	}
+
+	private void addDefaultOrder(List<OrderSpecifier<?>> orderSpecifiers) {
+		OrderSpecifier<Integer> roleOrderSpecifier = kuddyLevelOrderSpecifier();
+		orderSpecifiers.add(roleOrderSpecifier);
+		orderSpecifiers.add(profile.createdDate.desc());
+	}
+
+	private void applyGenderTypeFilter(ProfileSearchReqDto searchCriteria, BooleanBuilder builder) {
 		if (!searchCriteria.getGenderType().isBlank()) {
 			builder.and(profile.genderType.eq(GenderType.fromString(searchCriteria.getGenderType())));
 		}
 
-		// Area 검색 조건 (district)
+	}
+
+	private void applyAreaFilter(ProfileSearchReqDto searchCriteria, BooleanBuilder builder) {
 		if (!searchCriteria.getAreaName().isBlank()) {
 			builder.and(profileArea.area.district.eq(searchCriteria.getAreaName()));
 		}
+	}
 
-		// Interest Group & Content 조건
+	private void applyInterestFilter(ProfileSearchReqDto searchCriteria, BooleanBuilder builder) {
 		if (!searchCriteria.getInterestGroup().isBlank() && !searchCriteria.getInterestContent().isBlank()) {
-			BooleanExpression interestCondition = buildInterestCondition(
-					searchCriteria.getInterestGroup(), searchCriteria.getInterestContent()
-			);
+			BooleanExpression interestCondition = buildInterestCondition(searchCriteria.getInterestGroup(), searchCriteria.getInterestContent());
 			builder.and(interestCondition);
 		}
+	}
 
-		// Nickname 검색 조건
+	private void applyNicknameFilter(ProfileSearchReqDto searchCriteria, BooleanBuilder builder, List<OrderSpecifier<?>> orderSpecifiers) {
 		if (!searchCriteria.getNickname().isBlank()) {
 			BooleanExpression predicate = member.nickname.likeIgnoreCase("%" + searchCriteria.getNickname() + "%")
 					.and(member.nickname.ne(Member.FORBIDDEN_WORD));
 			builder.and(predicate);
+			NumberExpression<Integer> caseOrder = Expressions.cases()
+					.when(member.nickname.equalsIgnoreCase(searchCriteria.getNickname())).then(0)
+					.otherwise(1);
+
+			NumberExpression<Integer> lengthOrder = Expressions.numberTemplate(Integer.class, "LENGTH({0})", member.nickname);
+			orderSpecifiers.clear(); // 닉네임의 경우는 이름 정합도만 고려하여 정렬해야함
+			orderSpecifiers.add(caseOrder.asc());
+			orderSpecifiers.add(lengthOrder.asc());
 		}
+	}
 
-		NumberExpression<Integer> caseOrder = Expressions.cases()
-				.when(member.nickname.equalsIgnoreCase(searchCriteria.getNickname())).then(0)
-				.otherwise(1);
+	private void applyRoleTypeFilter(ProfileSearchReqDto searchCriteria, BooleanBuilder builder) {
 
-		NumberExpression<Integer> lengthOrder = Expressions.numberTemplate(Integer.class, "LENGTH({0})", member.nickname);
-
-		// RoleType 필터링
 		if (!searchCriteria.getRole().isBlank()) {
 			RoleType roleType = RoleType.fromString(searchCriteria.getRole());
 			builder.and(member.roleType.eq(roleType));
@@ -170,31 +194,36 @@ public class ProfileQueryService {
 					.or(member.roleType.eq(RoleType.TRAVELER));
 			builder.and(roleCondition);
 		}
+	}
 
-		List<Profile> profiles = queryFactory
-				.selectFrom(profile).distinct()
+	private List<Profile> executeQuery(BooleanBuilder builder,List<OrderSpecifier<?>> orderSpecifiers, Pageable pageable) {
+		return queryFactory.selectFrom(profile).distinct()
 				.leftJoin(profile.districts, profileArea)
 				.join(profile.member, member)
 				.where(builder)
-				.orderBy(
-						caseOrder.asc(),
-						lengthOrder.asc(),
-						profile.createdDate.desc()
-				)
+				.orderBy(orderSpecifiers.toArray(new OrderSpecifier<?>[0]))
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize())
 				.fetch();
+	}
 
-		JPAQuery<Long> countQuery = queryFactory
-				.select(profile.count())
+	private JPAQuery<Long> createCountQuery(BooleanBuilder builder) {
+		return queryFactory.select(profile.count())
 				.from(profile)
 				.leftJoin(profile.districts, profileArea)
 				.join(profile.member, member)
 				.where(builder);
+	}
 
-
-		return PageableExecutionUtils.getPage(profiles, pageable, countQuery::fetchOne);
-
+	private OrderSpecifier<Integer> kuddyLevelOrderSpecifier(){
+		return new CaseBuilder()
+				.when(profile.kuddyLevel.stringValue().eq(KuddyLevel.SOULMATE.name())).then(1)
+				.when(profile.kuddyLevel.stringValue().eq(KuddyLevel.COMPANION.name())).then(2)
+				.when(profile.kuddyLevel.stringValue().eq(KuddyLevel.FRIEND.name())).then(3)
+				.when(profile.kuddyLevel.stringValue().eq(KuddyLevel.EXPLORER.name())).then(4)
+				.when(profile.kuddyLevel.stringValue().eq(KuddyLevel.NOT_KUDDY.name())).then(5)
+				.otherwise(9999)
+				.asc();
 	}
 
 	private BooleanExpression buildInterestCondition(String interestGroup, String interestContent) {

--- a/common/src/main/java/com/kuddy/common/meetup/service/MeetupQueryService.java
+++ b/common/src/main/java/com/kuddy/common/meetup/service/MeetupQueryService.java
@@ -25,7 +25,7 @@ public class MeetupQueryService {
 		return jpaQueryFactory
 			.selectFrom(meetup)
 			.where(meetup.kuddy.id.eq(memberId).and(meetup.meetupStatus.notIn(excludedStatuses)))
-			.orderBy(meetup.createdDate.desc())
+			.orderBy(meetup.appointment.desc())
 			.fetch();
 	}
 	@Transactional(readOnly = true)
@@ -33,7 +33,7 @@ public class MeetupQueryService {
 		return jpaQueryFactory
 			.selectFrom(meetup)
 			.where(meetup.traveler.id.eq(memberId).and(meetup.meetupStatus.notIn(excludedStatuses)))
-			.orderBy(meetup.createdDate.desc())
+			.orderBy(meetup.appointment.desc())
 			.fetch();
 	}
 

--- a/common/src/main/java/com/kuddy/common/profile/domain/KuddyLevel.java
+++ b/common/src/main/java/com/kuddy/common/profile/domain/KuddyLevel.java
@@ -25,5 +25,9 @@ public enum KuddyLevel {
 			.findAny()
 			.orElse(EXPLORER);
 	}
+	public static String toString(KuddyLevel kuddyLevel){
+		return kuddyLevel.name;
+	}
+
 
 }


### PR DESCRIPTION
## 기능 명세
- [x] kuddy일 경우 level 순으로 정렬 후 프로필 생성 순으로 정렬
- [x] traveler일 경우 프로필 생성 순으로 정렬

## 결과 
- [POST] api/v1/profiles/search?page=0&size=10
기존 프로필 조회와 동일 

## 함께 의논할 점
> - 없으면 생략 