### PR TITLE
fix : 탈퇴 회원인 경우 필터링 추가

### DIFF
--- a/api-server/src/main/java/com/kuddy/apiserver/profile/service/ProfileQueryService.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/profile/service/ProfileQueryService.java
@@ -7,6 +7,7 @@ import static com.kuddy.common.profile.domain.QProfile.profile;
 import static com.kuddy.common.profile.domain.QProfileArea.*;
 
 
+import com.kuddy.common.member.domain.MemberStatus;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -197,6 +198,7 @@ public class ProfileQueryService {
 	}
 
 	private List<Profile> executeQuery(BooleanBuilder builder,List<OrderSpecifier<?>> orderSpecifiers, Pageable pageable) {
+		builder.and(member.memberStatus.ne(MemberStatus.WITHDRAW));
 		return queryFactory.selectFrom(profile).distinct()
 				.leftJoin(profile.districts, profileArea)
 				.join(profile.member, member)

--- a/api-server/src/main/java/com/kuddy/apiserver/spot/service/SpotService.java
+++ b/api-server/src/main/java/com/kuddy/apiserver/spot/service/SpotService.java
@@ -7,6 +7,7 @@ import com.kuddy.apiserver.spot.dto.SpotPageResDto;
 import com.kuddy.apiserver.spot.dto.SpotResDto;
 import com.kuddy.common.heart.domain.Heart;
 import com.kuddy.common.heart.repository.HeartRepository;
+import com.kuddy.common.member.domain.MemberStatus;
 import com.kuddy.common.member.domain.RoleType;
 import com.kuddy.common.page.PageInfo;
 import com.kuddy.common.profile.exception.ProfileNotFoundException;
@@ -236,9 +237,11 @@ public class SpotService {
         for(Heart heart : heartRepository.findAllBySpot(spot)) {
             if(heart.getMember().getProfile() == null)
                 throw new ProfileNotFoundException();
-            if(heart.getMember().getRoleType().equals(RoleType.KUDDY))
+            if(heart.getMember().getRoleType().equals(RoleType.KUDDY) && !heart.getMember().getMemberStatus().equals(
+                    MemberStatus.WITHDRAW))
                 kuddyList.add(PickMemberResDto.of(heart.getMember()));
-            if(heart.getMember().getRoleType().equals(RoleType.TRAVELER))
+            if(heart.getMember().getRoleType().equals(RoleType.TRAVELER) && !heart.getMember().getMemberStatus().equals(
+                    MemberStatus.WITHDRAW))
                 travelerList.add(PickMemberResDto.of(heart.getMember()));
         }
 


### PR DESCRIPTION
## 기능 명세
- [x] 프로필 검색 시 필터링하여 응답하도록 수정
- [x] 장소 상세 조회 시 좋아요 멤버 필터링하여 응답하도록 수정

## 결과 
api/v1/spots/1747895
api/v1/profiles/search?page=0&size=17
기존의 응답값과 동일합니다.

## 함께 의논할 점
> - 없으면 생략 